### PR TITLE
moved build statuses to chart + add in circle ci for mac osx

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,10 +1,14 @@
 # ![Datmo Logo](images/datmo-logo.png)
 [![PyPI version](https://badge.fury.io/py/datmo.svg)](https://badge.fury.io/py/datmo)
-[![Build Status](https://travis-ci.org/datmo/datmo.svg?branch=master)](https://travis-ci.org/datmo/datmo)
-[![Build status](https://ci.appveyor.com/api/projects/status/5302d8a23qr4ui4y/branch/master?svg=true)](https://ci.appveyor.com/project/asampat3090/datmo/branch/master)
 [![Coverage Status](https://coveralls.io/repos/github/datmo/datmo/badge.svg?branch=master)](https://coveralls.io/github/datmo/datmo?branch=master)
 [![Documentation Status](https://readthedocs.org/projects/datmo/badge/?version=latest)](http://datmo.readthedocs.io/en/latest/?badge=latest)
 [![Codacy Badge](https://api.codacy.com/project/badge/Grade/853b3d01b4424ac9aa72f9d5fead83b3)](https://www.codacy.com/app/datmo/datmo)
+
+| OS | CI testing on `master` |
+|----|--------------------|
+| <img height="20" src="http://icons.iconarchive.com/icons/dakirby309/simply-styled/256/OS-Linux-icon.png"> | [![Linux](https://travis-ci.org/datmo/datmo.svg?branch=master)](https://travis-ci.org/datmo/datmo) |
+| <img height="20" src="http://icons.iconarchive.com/icons/icons8/windows-8/128/Systems-Mac-Os-icon.png"> | [![CircleCI branch](https://circleci.com/gh/datmo/datmo.svg?style=shield)](https://circleci.com/gh/datmo/datmo) |
+| <img height="20" src="http://icons.iconarchive.com/icons/dakirby309/windows-8-metro/128/Folders-OS-Windows-8-Metro-icon.png"> | [![Windows](https://ci.appveyor.com/api/projects/status/5302d8a23qr4ui4y/branch/master?svg=true)](https://ci.appveyor.com/project/asampat3090/datmo/branch/master) |
 
 **Datmo** is an open source model tracking and reproducibility tool for developers. Use `datmo init` to turn any repository into a trackable task record with reusable environments and metrics logging.
 

--- a/README.md
+++ b/README.md
@@ -7,7 +7,6 @@
 | OS | CI testing on `master` |
 |----|--------------------|
 | <img height="20" src="http://icons.iconarchive.com/icons/dakirby309/simply-styled/256/OS-Linux-icon.png"> | [![Linux](https://travis-ci.org/datmo/datmo.svg?branch=master)](https://travis-ci.org/datmo/datmo) |
-| <img height="20" src="http://icons.iconarchive.com/icons/icons8/windows-8/128/Systems-Mac-Os-icon.png"> | [![CircleCI branch](https://circleci.com/gh/datmo/datmo.svg?style=shield)](https://circleci.com/gh/datmo/datmo) |
 | <img height="20" src="http://icons.iconarchive.com/icons/dakirby309/windows-8-metro/128/Folders-OS-Windows-8-Metro-icon.png"> | [![Windows](https://ci.appveyor.com/api/projects/status/5302d8a23qr4ui4y/branch/master?svg=true)](https://ci.appveyor.com/project/asampat3090/datmo/branch/master) |
 
 **Datmo** is an open source model tracking and reproducibility tool for developers. Use `datmo init` to turn any repository into a trackable task record with reusable environments and metrics logging.

--- a/README.rst
+++ b/README.rst
@@ -1,8 +1,15 @@
 |Datmo Logo|
 ============
 
-|PyPI version| |Build Status| |Build status| |Coverage Status|
-|Documentation Status| |Codacy Badge|
+|PyPI version| |Coverage Status| |Documentation Status| |Codacy Badge|
+
++------+----------------------------+
+| OS   | CI testing on ``master``   |
++======+============================+
+|      | |Linux|                    |
++------+----------------------------+
+|      | |Windows|                  |
++------+----------------------------+
 
 **Datmo** is an open source model tracking and reproducibility tool for
 developers. Use ``datmo init`` to turn any repository into a trackable
@@ -101,7 +108,7 @@ leveraging Datmo.
 |                                              |       config=config,                         |
 |                                              |       stats=stats,                           |
 |                                              |   ) # extra line                             |
-+------------------------------------------------+--------------------------------------------+
++----------------------------------------------+----------------------------------------------+
 
 In order to run the above code you can do the following.
 
@@ -304,16 +311,17 @@ Pull from remote
 If you are interested in sharing using the datmo protocol, you can visit
 `Datmo's website <https://datmo.com/product>`__
 
-.. |Datmo Logo| image:: images/datmo-logo.png
+.. |Datmo Logo| image:: ../images/datmo-logo.png
 .. |PyPI version| image:: https://badge.fury.io/py/datmo.svg
    :target: https://badge.fury.io/py/datmo
-.. |Build Status| image:: https://travis-ci.org/datmo/datmo.svg?branch=master
-   :target: https://travis-ci.org/datmo/datmo
-.. |Build status| image:: https://ci.appveyor.com/api/projects/status/5302d8a23qr4ui4y/branch/master?svg=true
-   :target: https://ci.appveyor.com/project/asampat3090/datmo/branch/master
 .. |Coverage Status| image:: https://coveralls.io/repos/github/datmo/datmo/badge.svg?branch=master
    :target: https://coveralls.io/github/datmo/datmo?branch=master
 .. |Documentation Status| image:: https://readthedocs.org/projects/datmo/badge/?version=latest
    :target: http://datmo.readthedocs.io/en/latest/?badge=latest
 .. |Codacy Badge| image:: https://api.codacy.com/project/badge/Grade/853b3d01b4424ac9aa72f9d5fead83b3
    :target: https://www.codacy.com/app/datmo/datmo
+.. |Linux| image:: https://travis-ci.org/datmo/datmo.svg?branch=master
+   :target: https://travis-ci.org/datmo/datmo
+.. |Windows| image:: https://ci.appveyor.com/api/projects/status/5302d8a23qr4ui4y/branch/master?svg=true
+   :target: https://ci.appveyor.com/project/asampat3090/datmo/branch/master
+

--- a/circle.yml
+++ b/circle.yml
@@ -11,7 +11,7 @@ machine:
     - echo "Creating python environments"
     - curl -o mconda.sh https://repo.continuum.io/miniconda/Miniconda3-latest-MacOSX-x86_64.sh
     - chmod +x mconda.sh
-    - PREFIX=/Users/distiller/miniconda ./mconda.sh -b -p $HOME/miniconda
+    - ./mconda.sh -b -p $HOME/miniconda
     - |
       for version in 2.7.10 3.5.1 3.6.1
       do

--- a/circle.yml
+++ b/circle.yml
@@ -1,0 +1,40 @@
+machine:
+
+  xcode:
+    version: 9.0
+
+  environment:
+    LOGGING_LEVEL: DEBUG
+    TEST_PACKAGE: python -m pytest
+
+  pre:
+    - echo "Creating python environments"
+    - curl -o mconda.sh https://repo.continuum.io/miniconda/Miniconda3-latest-MacOSX-x86_64.sh
+    - chmod +x mconda.sh
+    - ./mconda.sh -b -p $HOME/miniconda
+    - |
+      for version in 2.7.10 3.5.1 3.6.1
+      do
+        export PATH="$HOME/miniconda/bin:$PATH"  && conda create --yes -n datmo_env$version python=$version pip;
+        export PATH="$HOME/miniconda/bin:$PATH" && source activate datmo_env$version && pip install pytest --user && source deactivate datmo_env$version
+      done
+dependencies:
+
+  post:
+    - echo "Installing datmo to each environment"
+    - |
+      for version in 2.7.10 3.5.1 3.6.1
+      do
+        export PATH="$HOME/miniconda/bin:$PATH" && source activate datmo_env$version && python setup.py install && source deactivate datmo_env$version;
+      done
+test:
+  override:
+    # Avoiding loop here, so that each test shown in separate tab in circle-ci
+    - echo "Running Test with 2.7.10"
+    - export PATH="$HOME/miniconda/bin:$PATH" && source activate datmo_env2.7.10 && $TEST_PACKAGE  && source deactivate datmo_env2.7.10;
+    - echo "Running Test with 3.4.1"
+    - export PATH="$HOME/miniconda/bin:$PATH" && source activate datmo_env3.4.1 && $TEST_PACKAGE  && source deactivate datmo_env3.4.1;
+    - echo "Running Test with 3.5.1"
+    - export PATH="$HOME/miniconda/bin:$PATH" && source activate datmo_env3.5.1 && $TEST_PACKAGE && source deactivate datmo_env3.5.1;
+    - echo "Running Test with 3.6.1"
+    - export PATH="$HOME/miniconda/bin:$PATH" && source activate datmo_env3.6.1 && $TEST_PACKAGE && source deactivate datmo_env3.6.1;

--- a/circle.yml
+++ b/circle.yml
@@ -11,7 +11,7 @@ machine:
     - echo "Creating python environments"
     - curl -o mconda.sh https://repo.continuum.io/miniconda/Miniconda3-latest-MacOSX-x86_64.sh
     - chmod +x mconda.sh
-    - ./mconda.sh -b -p $HOME/miniconda
+    - PREFIX=/Users/distiller/miniconda ./mconda.sh -b -p $HOME/miniconda
     - |
       for version in 2.7.10 3.5.1 3.6.1
       do


### PR DESCRIPTION
added in circle ci config for mac osx but open source access to mac osx build not yet granted, so have removed it from the README for now