### PR TITLE
Fix alternative os builds

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@
 | OS | CI testing on `master` |
 |----|--------------------|
 | <img height="20" src="http://icons.iconarchive.com/icons/dakirby309/simply-styled/256/OS-Linux-icon.png"> | [![Linux](https://travis-ci.org/datmo/datmo.svg?branch=master)](https://travis-ci.org/datmo/datmo) |
+| <img height="20" src="http://icons.iconarchive.com/icons/icons8/windows-8/128/Systems-Mac-Os-icon.png"> | [![CircleCI branch](https://circleci.com/gh/datmo/datmo.svg?style=shield)](https://circleci.com/gh/datmo/datmo) |
 | <img height="20" src="http://icons.iconarchive.com/icons/dakirby309/windows-8-metro/128/Folders-OS-Windows-8-Metro-icon.png"> | [![Windows](https://ci.appveyor.com/api/projects/status/5302d8a23qr4ui4y/branch/master?svg=true)](https://ci.appveyor.com/project/asampat3090/datmo/branch/master) |
 
 **Datmo** is an open source model tracking and reproducibility tool for developers. Use `datmo init` to turn any repository into a trackable task record with reusable environments and metrics logging.

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -12,24 +12,24 @@ environment:
     - PYTHON: "C:\\Python27"
       PYTHON_VERSION: "2.7.x"
 
-    - PYTHON: "C:\\Python34"
-      PYTHON_VERSION: "3.4.x"
-
-    - PYTHON: "C:\\Python35"
-      PYTHON_VERSION: "3.5.x"
-
-    - PYTHON: "C:\\Python27-x64"
-      PYTHON_VERSION: "2.7.x"
-
-    - PYTHON: "C:\\Python34-x64"
-      DISTUTILS_USE_SDK: "1"
-      PYTHON_VERSION: "3.4.x"
-
-    - PYTHON: "C:\\Python35-x64"
-      PYTHON_VERSION: "3.5.x"
-
-    - PYTHON: "C:\\Python36-x64"
-      PYTHON_VERSION: "3.6.x"
+#    - PYTHON: "C:\\Python34"
+#      PYTHON_VERSION: "3.4.x"
+#
+#    - PYTHON: "C:\\Python35"
+#      PYTHON_VERSION: "3.5.x"
+#
+#    - PYTHON: "C:\\Python27-x64"
+#      PYTHON_VERSION: "2.7.x"
+#
+#    - PYTHON: "C:\\Python34-x64"
+#      DISTUTILS_USE_SDK: "1"
+#      PYTHON_VERSION: "3.4.x"
+#
+#    - PYTHON: "C:\\Python35-x64"
+#      PYTHON_VERSION: "3.5.x"
+#
+#    - PYTHON: "C:\\Python36-x64"
+#      PYTHON_VERSION: "3.6.x"
 
 build: false
 init:

--- a/circle.yml
+++ b/circle.yml
@@ -32,8 +32,8 @@ test:
     # Avoiding loop here, so that each test shown in separate tab in circle-ci
     - echo "Running Test with 2.7.10"
     - export PATH="$HOME/miniconda/bin:$PATH" && source activate datmo_env2.7.10 && $TEST_PACKAGE  && source deactivate datmo_env2.7.10;
-    - echo "Running Test with 3.4.1"
-    - export PATH="$HOME/miniconda/bin:$PATH" && source activate datmo_env3.4.1 && $TEST_PACKAGE  && source deactivate datmo_env3.4.1;
+#    - echo "Running Test with 3.4.1"
+#    - export PATH="$HOME/miniconda/bin:$PATH" && source activate datmo_env3.4.1 && $TEST_PACKAGE  && source deactivate datmo_env3.4.1;
     - echo "Running Test with 3.5.1"
     - export PATH="$HOME/miniconda/bin:$PATH" && source activate datmo_env3.5.1 && $TEST_PACKAGE && source deactivate datmo_env3.5.1;
     - echo "Running Test with 3.6.1"

--- a/datmo/cli/command/base.py
+++ b/datmo/cli/command/base.py
@@ -3,6 +3,7 @@
 from datmo.core.util.i18n import get as __
 from datmo.core.util.exceptions import ClassMethodNotFound
 from datmo.cli.parser import get_datmo_parser
+from datmo.core.util.logger import DatmoLogger
 from datmo.core.util.misc_functions import parameterized
 
 
@@ -10,6 +11,7 @@ class BaseCommand(object):
     def __init__(self, home, cli_helper):
         self.home = home
         self.cli_helper = cli_helper
+        self.logger = DatmoLogger.get_logger(__name__)
         self.parser = get_datmo_parser()
 
     def parse(self, args):

--- a/datmo/cli/command/project.py
+++ b/datmo/cli/command/project.py
@@ -50,7 +50,7 @@ class ProjectCommand(BaseCommand):
                             "name": name,
                             "path": self.home
                         }))
-            except:
+            except Exception:
                 self.cli_helper.echo(
                     __("info", "cli.project.init.create.failure", {
                         "name": name,
@@ -83,7 +83,7 @@ class ProjectCommand(BaseCommand):
                             "name": name,
                             "path": self.home
                         }))
-            except:
+            except Exception:
                 self.cli_helper.echo(
                     __("info", "cli.project.init.update.failure", {
                         "name": name,

--- a/datmo/cli/command/task.py
+++ b/datmo/cli/command/task.py
@@ -13,14 +13,12 @@ from datmo.core.util.i18n import get as __
 from datmo.core.util.misc_functions import mutually_exclusive
 from datmo.cli.command.project import ProjectCommand
 from datmo.core.controller.task import TaskController
-from datmo.core.util.logger import DatmoLogger
 from datmo.core.util.exceptions import RequiredArgumentMissing
 
 
 class TaskCommand(ProjectCommand):
     def __init__(self, home, cli_helper):
         super(TaskCommand, self).__init__(home, cli_helper)
-        self.logger = DatmoLogger.get_logger(__name__)
         self.task_controller = TaskController(home=home)
 
     def task(self):

--- a/datmo/cli/command/task.py
+++ b/datmo/cli/command/task.py
@@ -103,7 +103,7 @@ class TaskCommand(ProjectCommand):
                     self.cli_helper.echo(
                         __("info", "cli.task.stop.all.success"))
             return result
-        except:
+        except Exception:
             if "id" in input_dict:
                 self.cli_helper.echo(
                     __("error", "cli.task.stop", input_dict['id']))

--- a/datmo/cli/command/tests/test_session.py
+++ b/datmo/cli/command/tests/test_session.py
@@ -5,9 +5,8 @@ from __future__ import division
 from __future__ import print_function
 from __future__ import unicode_literals
 
-import shutil
 import tempfile
-from io import open
+import platform
 try:
     to_unicode = unicode
 except NameError:
@@ -23,7 +22,8 @@ from datmo.core.util.exceptions import ProjectNotInitializedException
 class TestSession():
     def setup_class(self):
         # provide mountable tmp directory for docker
-        tempfile.tempdir = '/tmp'
+        tempfile.tempdir = "/tmp" if not platform.system(
+        ) == "Windows" else None
         test_datmo_dir = os.environ.get('TEST_DATMO_DIR',
                                         tempfile.gettempdir())
         self.temp_dir = tempfile.mkdtemp(dir=test_datmo_dir)

--- a/datmo/cli/command/tests/test_snapshot.py
+++ b/datmo/cli/command/tests/test_snapshot.py
@@ -28,6 +28,7 @@ from datmo.cli.command.task import TaskCommand
 from datmo.core.util.exceptions import (ProjectNotInitializedException,
                                         MutuallyExclusiveArguments,
                                         SnapshotCreateFromTaskArgs)
+from datmo.core.util.misc_functions import pytest_docker_environment_failed_instantiation
 
 
 class TestSnapshot():
@@ -106,7 +107,7 @@ class TestSnapshot():
         self.snapshot.parse(["snapshot", "create", "--help"])
         assert self.snapshot.execute()
 
-    def test_snapshot_command(self):
+    def test_snapshot_create(self):
         self.__set_variables()
         test_message = "this is a test message"
         test_label = "test label"
@@ -183,10 +184,10 @@ class TestSnapshot():
         snapshot_id_1 = self.snapshot.execute()
         assert snapshot_id_1
 
-    def test_datmo_snapshot_create_from_task(self):
+    @pytest_docker_environment_failed_instantiation
+    def test_snapshot_create_from_task(self):
         self.__set_variables()
         test_message = "this is a test message"
-        test_code_id = "test_code_id"
 
         # create task
         test_command = "sh -c 'echo accuracy:0.45'"
@@ -213,6 +214,7 @@ class TestSnapshot():
         snapshot_id = self.snapshot.execute()
         assert snapshot_id
 
+    @pytest_docker_environment_failed_instantiation
     def test_snapshot_create_from_task_fail_user_inputs(self):
         self.__set_variables()
         test_message = "this is a test message"
@@ -546,7 +548,8 @@ class TestSnapshot():
 
         # remove datmo_task folder to have no changes before checkout
         datmo_tasks_dirpath = os.path.join(self.snapshot.home, "datmo_tasks")
-        shutil.rmtree(datmo_tasks_dirpath)
+        if os.path.exists(datmo_tasks_dirpath):
+            shutil.rmtree(datmo_tasks_dirpath)
 
         # Test when optional parameters are not given
         self.snapshot.parse(["snapshot", "checkout", "--id", snapshot_id])

--- a/datmo/cli/command/tests/test_snapshot.py
+++ b/datmo/cli/command/tests/test_snapshot.py
@@ -30,14 +30,13 @@ from datmo.core.util.exceptions import (ProjectNotInitializedException,
                                         SnapshotCreateFromTaskArgs)
 from datmo.core.util.misc_functions import pytest_docker_environment_failed_instantiation
 
+# provide mountable tmp directory for docker
+tempfile.tempdir = "/tmp" if not platform.system() == "Windows" else None
+test_datmo_dir = os.environ.get('TEST_DATMO_DIR', tempfile.gettempdir())
+
 
 class TestSnapshot():
     def setup_class(self):
-        # provide mountable tmp directory for docker
-        tempfile.tempdir = "/tmp" if not platform.system(
-        ) == "Windows" else None
-        test_datmo_dir = os.environ.get('TEST_DATMO_DIR',
-                                        tempfile.gettempdir())
         self.temp_dir = tempfile.mkdtemp(dir=test_datmo_dir)
         self.cli_helper = Helper()
 
@@ -184,7 +183,7 @@ class TestSnapshot():
         snapshot_id_1 = self.snapshot.execute()
         assert snapshot_id_1
 
-    @pytest_docker_environment_failed_instantiation
+    @pytest_docker_environment_failed_instantiation(test_datmo_dir)
     def test_snapshot_create_from_task(self):
         self.__set_variables()
         test_message = "this is a test message"
@@ -214,7 +213,7 @@ class TestSnapshot():
         snapshot_id = self.snapshot.execute()
         assert snapshot_id
 
-    @pytest_docker_environment_failed_instantiation
+    @pytest_docker_environment_failed_instantiation(test_datmo_dir)
     def test_snapshot_create_from_task_fail_user_inputs(self):
         self.__set_variables()
         test_message = "this is a test message"

--- a/datmo/cli/command/tests/test_task.py
+++ b/datmo/cli/command/tests/test_task.py
@@ -31,14 +31,13 @@ from datmo.core.entity.task import Task as CoreTask
 from datmo.core.util.exceptions import ProjectNotInitializedException, MutuallyExclusiveArguments, RequiredArgumentMissing
 from datmo.core.util.misc_functions import pytest_docker_environment_failed_instantiation
 
+# provide mountable tmp directory for docker
+tempfile.tempdir = "/tmp" if not platform.system() == "Windows" else None
+test_datmo_dir = os.environ.get('TEST_DATMO_DIR', tempfile.gettempdir())
+
 
 class TestTaskCommand():
     def setup_class(self):
-        # provide mountable tmp directory for docker
-        tempfile.tempdir = "/tmp" if not platform.system(
-        ) == "Windows" else None
-        test_datmo_dir = os.environ.get('TEST_DATMO_DIR',
-                                        tempfile.gettempdir())
         self.temp_dir = tempfile.mkdtemp(dir=test_datmo_dir)
         self.cli_helper = Helper()
 
@@ -78,7 +77,7 @@ class TestTaskCommand():
         result = self.task.execute()
         assert not result
 
-    @pytest_docker_environment_failed_instantiation
+    @pytest_docker_environment_failed_instantiation(test_datmo_dir)
     def test_task_run(self):
         # TODO: Adding test with `--interactive` argument and terminate inside container
         self.__set_variables()
@@ -125,7 +124,7 @@ class TestTaskCommand():
         assert result.results == {"accuracy": "0.45"}
         assert result.status == "SUCCESS"
 
-    @pytest_docker_environment_failed_instantiation
+    @pytest_docker_environment_failed_instantiation(test_datmo_dir)
     def test_task_run_string_command(self):
         # TODO: Adding test with `--interactive` argument and terminate inside container
         self.__set_variables()
@@ -194,7 +193,7 @@ class TestTaskCommand():
     #         assert result.results == {"accuracy": "0.45"}
     #         assert result.status == "SUCCESS"
 
-    @pytest_docker_environment_failed_instantiation
+    @pytest_docker_environment_failed_instantiation(test_datmo_dir)
     def test_task_run_notebook(self):
         self.__set_variables()
         # Test success case
@@ -262,7 +261,7 @@ class TestTaskCommand():
             exception_thrown = True
         assert exception_thrown
 
-    @pytest_docker_environment_failed_instantiation
+    @pytest_docker_environment_failed_instantiation(test_datmo_dir)
     def test_task_stop_success(self):
         # 1) Test stop with task_id
         # 2) Test stop with all

--- a/datmo/cli/command/tests/test_task.py
+++ b/datmo/cli/command/tests/test_task.py
@@ -29,6 +29,7 @@ from datmo.cli.command.project import ProjectCommand
 from datmo.cli.command.task import TaskCommand
 from datmo.core.entity.task import Task as CoreTask
 from datmo.core.util.exceptions import ProjectNotInitializedException, MutuallyExclusiveArguments, RequiredArgumentMissing
+from datmo.core.util.misc_functions import pytest_docker_environment_failed_instantiation
 
 
 class TestTaskCommand():
@@ -65,7 +66,7 @@ class TestTaskCommand():
             failed = True
         assert failed
 
-    def test_snapshot_command(self):
+    def test_task_command(self):
         self.__set_variables()
         self.task.parse(["task"])
         assert self.task.execute()
@@ -77,6 +78,7 @@ class TestTaskCommand():
         result = self.task.execute()
         assert not result
 
+    @pytest_docker_environment_failed_instantiation
     def test_task_run(self):
         # TODO: Adding test with `--interactive` argument and terminate inside container
         self.__set_variables()
@@ -123,6 +125,7 @@ class TestTaskCommand():
         assert result.results == {"accuracy": "0.45"}
         assert result.status == "SUCCESS"
 
+    @pytest_docker_environment_failed_instantiation
     def test_task_run_string_command(self):
         # TODO: Adding test with `--interactive` argument and terminate inside container
         self.__set_variables()
@@ -191,6 +194,7 @@ class TestTaskCommand():
     #         assert result.results == {"accuracy": "0.45"}
     #         assert result.status == "SUCCESS"
 
+    @pytest_docker_environment_failed_instantiation
     def test_task_run_notebook(self):
         self.__set_variables()
         # Test success case
@@ -258,6 +262,7 @@ class TestTaskCommand():
             exception_thrown = True
         assert exception_thrown
 
+    @pytest_docker_environment_failed_instantiation
     def test_task_stop_success(self):
         # 1) Test stop with task_id
         # 2) Test stop with all

--- a/datmo/core/controller/base.py
+++ b/datmo/core/controller/base.py
@@ -1,6 +1,7 @@
 import os
 
 from datmo.core.util.i18n import get as __
+from datmo.core.util.logger import DatmoLogger
 from datmo.core.util import get_class_contructor
 from datmo.core.util.json_store import JSONStore
 from datmo.core.util.exceptions import (InvalidProjectPathException,
@@ -47,6 +48,7 @@ class BaseController(object):
             raise InvalidProjectPathException(
                 __("error", "controller.base.__init__", home))
         self.config = JSONStore(os.path.join(self.home, ".datmo", ".config"))
+        self.logger = DatmoLogger.get_logger(__name__)
         # property caches and initial values
         self._dal = None
         self._model = None
@@ -111,10 +113,9 @@ class BaseController(object):
     def is_initialized(self):
         if not self._is_initialized:
             if self.code_driver.is_initialized and \
-                self.environment_driver.is_initialized and \
-                    self.file_driver.is_initialized:
-                if self.model:
-                    self._is_initialized = True
+                self.file_driver.is_initialized and \
+                 self.model:
+                self._is_initialized = True
         return self._is_initialized
 
     def dal_instantiate(self):

--- a/datmo/core/controller/code/code.py
+++ b/datmo/core/controller/code/code.py
@@ -1,7 +1,7 @@
 from datmo.core.util.i18n import get as __
 from datmo.core.controller.base import BaseController
 from datmo.core.entity.code import Code
-from datmo.core.util.exceptions import PathDoesNotExist
+from datmo.core.util.exceptions import PathDoesNotExist, EnvironmentInitFailed
 
 
 class CodeController(BaseController):
@@ -24,7 +24,11 @@ class CodeController(BaseController):
     """
 
     def __init__(self, home):
-        super(CodeController, self).__init__(home)
+        try:
+            super(CodeController, self).__init__(home)
+        except EnvironmentInitFailed:
+            self.logger.warning(
+                __("warn", "controller.general.environment.failed"))
 
     def create(self, commit_id=None):
         """Create a Code object

--- a/datmo/core/controller/code/driver/git.py
+++ b/datmo/core/controller/code/driver/git.py
@@ -133,7 +133,7 @@ class GitCodeDriver(CodeDriver):
                 self.add("-A")
                 new_commit_bool = self.commit(
                     options=["-m", "auto commit by datmo"])
-            except:
+            except Exception:
                 self.add("-A")
                 new_commit_bool = self.commit(
                     options=["-m", "auto initial commit by datmo"])

--- a/datmo/core/controller/code/driver/tests/test_git.py
+++ b/datmo/core/controller/code/driver/tests/test_git.py
@@ -264,7 +264,7 @@ class TestGitCodeDriver():
         failed = False
         try:
             self.git_code_manager.latest_commit()
-        except:
+        except Exception:
             failed = True
         assert failed
 

--- a/datmo/core/controller/environment/driver/__init__.py
+++ b/datmo/core/controller/environment/driver/__init__.py
@@ -24,6 +24,20 @@ class EnvironmentDriver(with_metaclass(ABCMeta, object)):
         pass
 
     @abstractmethod
+    def init(self):
+        """Initialize the environment driver
+
+        Returns
+        -------
+        bool
+            returns True if success else False
+
+        Raises
+        ------
+        EnvironmentInitFailed
+        """
+
+    @abstractmethod
     def create(self, path=None, output_path=None, language=None):
         """Create datmo environment definition
 

--- a/datmo/core/controller/environment/driver/tests/test_dockerenv.py
+++ b/datmo/core/controller/environment/driver/tests/test_dockerenv.py
@@ -23,6 +23,10 @@ from datmo.core.util.exceptions import (
     EnvironmentContainerNotFound)
 from datmo.core.util.misc_functions import pytest_docker_environment_failed_instantiation
 
+# provide mountable tmp directory for docker
+tempfile.tempdir = "/tmp" if not platform.system() == "Windows" else None
+test_datmo_dir = os.environ.get('TEST_DATMO_DIR', tempfile.gettempdir())
+
 
 class TestDockerEnv():
     # TODO: Add more cases for each test
@@ -31,11 +35,6 @@ class TestDockerEnv():
     """
 
     def setup_method(self):
-        # provide mountable tmp directory for docker
-        tempfile.tempdir = "/tmp" if not platform.system(
-        ) == "Windows" else None
-        test_datmo_dir = os.environ.get('TEST_DATMO_DIR',
-                                        tempfile.gettempdir())
         self.temp_dir = tempfile.mkdtemp(dir=test_datmo_dir)
         # Test the default parameters
         self.docker_environment_manager = \
@@ -58,7 +57,7 @@ class TestDockerEnv():
         assert self.docker_environment_manager.prefix
         assert self.docker_environment_manager.type
 
-    @pytest_docker_environment_failed_instantiation
+    @pytest_docker_environment_failed_instantiation(test_datmo_dir)
     def test_init_success(self):
         init_result = self.docker_environment_manager.init()
         assert init_result and \
@@ -160,7 +159,7 @@ class TestDockerEnv():
             failed = True
         assert failed
 
-    @pytest_docker_environment_failed_instantiation
+    @pytest_docker_environment_failed_instantiation(test_datmo_dir)
     def test_build(self):
         name = str(uuid.uuid1())
         path = os.path.join(self.docker_environment_manager.filepath,
@@ -197,7 +196,7 @@ class TestDockerEnv():
         # teardown
         self.docker_environment_manager.remove(name, force=True)
 
-    @pytest_docker_environment_failed_instantiation
+    @pytest_docker_environment_failed_instantiation(test_datmo_dir)
     def test_run(self):
         # TODO: add more options for run w/ volumes etc
         # Keeping stdin_open and tty as either (True, True) or (False, False).
@@ -251,7 +250,7 @@ class TestDockerEnv():
         # teardown image
         self.docker_environment_manager.remove(image_name, force=True)
 
-    @pytest_docker_environment_failed_instantiation
+    @pytest_docker_environment_failed_instantiation(test_datmo_dir)
     def test_interactive_run(self):
         # keeping stdin_open, tty as True
         # build image
@@ -336,7 +335,7 @@ class TestDockerEnv():
         # teardown image
         self.docker_environment_manager.remove(image_name, force=True)
 
-    @pytest_docker_environment_failed_instantiation
+    @pytest_docker_environment_failed_instantiation(test_datmo_dir)
     def test_stop(self):
         name = str(uuid.uuid1())
         path = os.path.join(self.docker_environment_manager.filepath,
@@ -366,7 +365,7 @@ class TestDockerEnv():
         # teardown
         self.docker_environment_manager.remove(name, force=True)
 
-    @pytest_docker_environment_failed_instantiation
+    @pytest_docker_environment_failed_instantiation(test_datmo_dir)
     def test_remove(self):
         name = str(uuid.uuid1())
         # Test if no image present and no containers
@@ -390,13 +389,13 @@ class TestDockerEnv():
         result = self.docker_environment_manager.remove(name, force=True)
         assert result == True
 
-    @pytest_docker_environment_failed_instantiation
+    @pytest_docker_environment_failed_instantiation(test_datmo_dir)
     def test_get_tags_for_docker_repository(self):
         result = self.docker_environment_manager.get_tags_for_docker_repository(
             "hello-world")
         assert 'latest' in result
 
-    @pytest_docker_environment_failed_instantiation
+    @pytest_docker_environment_failed_instantiation(test_datmo_dir)
     def test_build_image(self):
         image_name = str(uuid.uuid1())
         dockerfile_path = os.path.join(
@@ -410,7 +409,7 @@ class TestDockerEnv():
         assert result == True
         self.docker_environment_manager.remove_image(image_name, force=True)
 
-    @pytest_docker_environment_failed_instantiation
+    @pytest_docker_environment_failed_instantiation(test_datmo_dir)
     def test_get_image(self):
         failed = False
         try:
@@ -434,7 +433,7 @@ class TestDockerEnv():
         assert image_name + ":latest" in tags
         self.docker_environment_manager.remove_image(image_name, force=True)
 
-    @pytest_docker_environment_failed_instantiation
+    @pytest_docker_environment_failed_instantiation(test_datmo_dir)
     def test_list_images(self):
         # TODO: Test out all input permutations
         image_name = str(uuid.uuid1())
@@ -460,7 +459,7 @@ class TestDockerEnv():
         assert image_name + ":latest" in group_flat
         self.docker_environment_manager.remove_image(image_name, force=True)
 
-    @pytest_docker_environment_failed_instantiation
+    @pytest_docker_environment_failed_instantiation(test_datmo_dir)
     def test_search_images(self):
         image_name = str(uuid.uuid1())
         dockerfile_path = os.path.join(
@@ -475,7 +474,7 @@ class TestDockerEnv():
         assert len(result) > 0
         self.docker_environment_manager.remove_image(image_name, force=True)
 
-    @pytest_docker_environment_failed_instantiation
+    @pytest_docker_environment_failed_instantiation(test_datmo_dir)
     def test_remove_image(self):
         image_name = str(uuid.uuid1())
         dockerfile_path = os.path.join(
@@ -496,7 +495,7 @@ class TestDockerEnv():
             image_name, force=True)
         assert result == True
 
-    @pytest_docker_environment_failed_instantiation
+    @pytest_docker_environment_failed_instantiation(test_datmo_dir)
     def test_remove_images(self):
         # TODO: Test out all input permutations
         image_name = str(uuid.uuid1())
@@ -518,7 +517,7 @@ class TestDockerEnv():
             name=image_name, force=True)
         assert result == True
 
-    @pytest_docker_environment_failed_instantiation
+    @pytest_docker_environment_failed_instantiation(test_datmo_dir)
     def test_run_container(self):
         # TODO: test with all variables provided
         image_name = str(uuid.uuid1())
@@ -549,7 +548,7 @@ class TestDockerEnv():
             image_name, force=True)
         self.docker_environment_manager.remove_image(image_name, force=True)
 
-    @pytest_docker_environment_failed_instantiation
+    @pytest_docker_environment_failed_instantiation(test_datmo_dir)
     def test_get_container(self):
         failed = False
         try:
@@ -575,7 +574,7 @@ class TestDockerEnv():
             image_name, force=True)
         self.docker_environment_manager.remove_image(image_name, force=True)
 
-    @pytest_docker_environment_failed_instantiation
+    @pytest_docker_environment_failed_instantiation(test_datmo_dir)
     def test_list_containers(self):
         # TODO: Test out all input permutations
         image_name = str(uuid.uuid1())
@@ -595,7 +594,7 @@ class TestDockerEnv():
             image_name, force=True)
         self.docker_environment_manager.remove_image(image_name, force=True)
 
-    @pytest_docker_environment_failed_instantiation
+    @pytest_docker_environment_failed_instantiation(test_datmo_dir)
     def test_stop_container(self):
         image_name = str(uuid.uuid1())
         dockerfile_path = os.path.join(
@@ -616,7 +615,7 @@ class TestDockerEnv():
             image_name, force=True)
         self.docker_environment_manager.remove_image(image_name, force=True)
 
-    @pytest_docker_environment_failed_instantiation
+    @pytest_docker_environment_failed_instantiation(test_datmo_dir)
     def test_remove_container(self):
         image_name = str(uuid.uuid1())
         dockerfile_path = os.path.join(
@@ -640,7 +639,7 @@ class TestDockerEnv():
         assert result == True
         self.docker_environment_manager.remove_image(image_name, force=True)
 
-    @pytest_docker_environment_failed_instantiation
+    @pytest_docker_environment_failed_instantiation(test_datmo_dir)
     def test_log_container(self):
         # TODO: Do a more comprehensive test, test out optional variables
         # TODO: Test out more commands at the system level
@@ -671,7 +670,7 @@ class TestDockerEnv():
             image_name, force=True)
         self.docker_environment_manager.remove_image(image_name, force=True)
 
-    @pytest_docker_environment_failed_instantiation
+    @pytest_docker_environment_failed_instantiation(test_datmo_dir)
     def test_stop_remove_containers_by_term(self):
         # 1) Test with image_name (random container name), match with image_name
         # 2) Test with image_name and name given, match with name

--- a/datmo/core/controller/environment/environment.py
+++ b/datmo/core/controller/environment/environment.py
@@ -28,7 +28,6 @@ class EnvironmentController(BaseController):
         List all environments within the project
     delete(id)
         Delete the specified environment from the project
-
     """
 
     def __init__(self, home):
@@ -174,6 +173,7 @@ class EnvironmentController(BaseController):
         PathDoesNotExist
             if the specified Environment does not exist.
         """
+        self.environment_driver.init()
         environment_obj = self.dal.environment.get_by_id(environment_id)
         if not environment_obj:
             raise PathDoesNotExist(
@@ -223,6 +223,7 @@ class EnvironmentController(BaseController):
         logs : str
             string version of output logs for the container
         """
+        self.environment_driver.init()
         # TODO: Check hardware info here if different from creation time
         final_return_code, run_id, logs = \
             self.environment_driver.run(environment_id, options, log_filepath)
@@ -250,6 +251,7 @@ class EnvironmentController(BaseController):
         PathDoesNotExist
             if the specified Environment does not exist.
         """
+        self.environment_driver.init()
         environment_obj = self.dal.environment.get_by_id(environment_id)
         if not environment_obj:
             raise PathDoesNotExist(
@@ -295,6 +297,7 @@ class EnvironmentController(BaseController):
         RequiredArgumentMissing
         TooManyArguments
         """
+        self.environment_driver.init()
         if not (run_id or match_string or all):
             raise RequiredArgumentMissing()
         if sum(map(bool, [run_id, match_string, all])) > 1:

--- a/datmo/core/controller/environment/tests/test_environment.py
+++ b/datmo/core/controller/environment/tests/test_environment.py
@@ -22,14 +22,13 @@ from datmo.core.util.exceptions import (
     TooManyArgumentsFound)
 from datmo.core.util.misc_functions import pytest_docker_environment_failed_instantiation
 
+# provide mountable tmp directory for docker
+tempfile.tempdir = "/tmp" if not platform.system() == "Windows" else None
+test_datmo_dir = os.environ.get('TEST_DATMO_DIR', tempfile.gettempdir())
+
 
 class TestEnvironmentController():
     def setup_method(self):
-        # provide mountable tmp directory for docker
-        tempfile.tempdir = "/tmp" if not platform.system(
-        ) == "Windows" else None
-        test_datmo_dir = os.environ.get('TEST_DATMO_DIR',
-                                        tempfile.gettempdir())
         self.temp_dir = tempfile.mkdtemp(dir=test_datmo_dir)
         self.project = ProjectController(self.temp_dir)
         self.environment = EnvironmentController(self.temp_dir)
@@ -216,7 +215,7 @@ class TestEnvironmentController():
         assert environment_obj_5.id != environment_obj_1.id
         assert environment_obj_5.id != environment_obj_4.id
 
-    @pytest_docker_environment_failed_instantiation
+    @pytest_docker_environment_failed_instantiation(test_datmo_dir)
     def test_build(self):
         # 1) Test build when no environment given
         # 2) Test build when definition path exists and given
@@ -283,7 +282,7 @@ class TestEnvironmentController():
         self.environment.delete(environment_obj_1.id)
         self.environment.delete(environment_obj_4.id)
 
-    @pytest_docker_environment_failed_instantiation
+    @pytest_docker_environment_failed_instantiation(test_datmo_dir)
     def test_run(self):
         # 1) Test run simple command with simple Dockerfile
         self.project.init("test5", "test description")
@@ -378,7 +377,7 @@ class TestEnvironmentController():
         # teardown
         self.environment.delete(environment_obj.id)
 
-    @pytest_docker_environment_failed_instantiation
+    @pytest_docker_environment_failed_instantiation(test_datmo_dir)
     def test_interactive_run(self):
         # 1) Test run interactive terminal in environment
         # 2) Test run jupyter notebook in environment
@@ -506,7 +505,7 @@ class TestEnvironmentController():
             environment_obj_1 in result and \
             environment_obj_2 in result
 
-    @pytest_docker_environment_failed_instantiation
+    @pytest_docker_environment_failed_instantiation(test_datmo_dir)
     def test_delete(self):
         self.project.init("test5", "test description")
 
@@ -535,7 +534,7 @@ class TestEnvironmentController():
         assert result == True and \
             thrown == True
 
-    @pytest_docker_environment_failed_instantiation
+    @pytest_docker_environment_failed_instantiation(test_datmo_dir)
     def test_stop_failure(self):
         # 1) Test failure with RequiredArgumentMissing
         # 2) Test failure with TooManyArgumentsFound
@@ -556,7 +555,7 @@ class TestEnvironmentController():
             failed = True
         assert failed
 
-    @pytest_docker_environment_failed_instantiation
+    @pytest_docker_environment_failed_instantiation(test_datmo_dir)
     def test_stop_success(self):
         # TODO: test more run options
         # 1) Test run_id input to stop

--- a/datmo/core/controller/environment/tests/test_environment.py
+++ b/datmo/core/controller/environment/tests/test_environment.py
@@ -20,6 +20,7 @@ from datmo.core.controller.environment.environment import \
 from datmo.core.util.exceptions import (
     EntityNotFound, EnvironmentDoesNotExist, RequiredArgumentMissing,
     TooManyArgumentsFound)
+from datmo.core.util.misc_functions import pytest_docker_environment_failed_instantiation
 
 
 class TestEnvironmentController():
@@ -215,6 +216,7 @@ class TestEnvironmentController():
         assert environment_obj_5.id != environment_obj_1.id
         assert environment_obj_5.id != environment_obj_4.id
 
+    @pytest_docker_environment_failed_instantiation
     def test_build(self):
         # 1) Test build when no environment given
         # 2) Test build when definition path exists and given
@@ -281,6 +283,7 @@ class TestEnvironmentController():
         self.environment.delete(environment_obj_1.id)
         self.environment.delete(environment_obj_4.id)
 
+    @pytest_docker_environment_failed_instantiation
     def test_run(self):
         # 1) Test run simple command with simple Dockerfile
         self.project.init("test5", "test description")
@@ -375,6 +378,7 @@ class TestEnvironmentController():
         # teardown
         self.environment.delete(environment_obj.id)
 
+    @pytest_docker_environment_failed_instantiation
     def test_interactive_run(self):
         # 1) Test run interactive terminal in environment
         # 2) Test run jupyter notebook in environment
@@ -502,6 +506,7 @@ class TestEnvironmentController():
             environment_obj_1 in result and \
             environment_obj_2 in result
 
+    @pytest_docker_environment_failed_instantiation
     def test_delete(self):
         self.project.init("test5", "test description")
 
@@ -530,6 +535,7 @@ class TestEnvironmentController():
         assert result == True and \
             thrown == True
 
+    @pytest_docker_environment_failed_instantiation
     def test_stop_failure(self):
         # 1) Test failure with RequiredArgumentMissing
         # 2) Test failure with TooManyArgumentsFound
@@ -550,6 +556,7 @@ class TestEnvironmentController():
             failed = True
         assert failed
 
+    @pytest_docker_environment_failed_instantiation
     def test_stop_success(self):
         # TODO: test more run options
         # 1) Test run_id input to stop

--- a/datmo/core/controller/file/driver/local.py
+++ b/datmo/core/controller/file/driver/local.py
@@ -1,4 +1,5 @@
 import os
+import stat
 import shutil
 import glob
 import hashlib
@@ -256,7 +257,7 @@ class LocalFileDriver(FileDriver):
         shutil.rmtree(temp_collection_path)
 
         # Change permissions to read only for collection_path. File collection is immutable
-        mode = 0o755
+        mode = stat.S_IRWXU | stat.S_IRGRP | stat.S_IXGRP | stat.S_IROTH | stat.S_IXOTH
 
         for root, dirs, files in os.walk(collection_path, topdown=False):
             for dir in [os.path.join(root, d) for d in dirs]:

--- a/datmo/core/controller/file/driver/tests/test_local.py
+++ b/datmo/core/controller/file/driver/tests/test_local.py
@@ -6,6 +6,7 @@ from __future__ import print_function
 from __future__ import unicode_literals
 
 import os
+import stat
 import tempfile
 import platform
 from io import TextIOWrapper
@@ -14,7 +15,7 @@ from datmo.core.controller.file.driver.local import LocalFileDriver
 from datmo.core.util.exceptions import PathDoesNotExist
 
 
-class TestLocalFileManager():
+class TestLocalFileDriver():
     # TODO: Add more cases for each test
     """
     Checks all functions of the LocalFileDriver

--- a/datmo/core/controller/file/driver/tests/test_local.py
+++ b/datmo/core/controller/file/driver/tests/test_local.py
@@ -6,7 +6,6 @@ from __future__ import print_function
 from __future__ import unicode_literals
 
 import os
-import stat
 import tempfile
 import platform
 from io import TextIOWrapper
@@ -294,24 +293,45 @@ class TestLocalFileDriver():
 
         assert os.path.isdir(collection_path)
         assert len(os.listdir(collections_path)) == 2
-        assert os.path.isdir(os.path.join(collection_path,
-                                       "dirpath1")) and \
-               (oct(os.stat(os.path.join(collection_path,
-                                        "dirpath1")).st_mode & 0o777) == '0o755' or
-                oct(os.stat(os.path.join(collection_path,
-                                         "dirpath1")).st_mode & 0o777) == '0755')
-        assert os.path.isdir(os.path.join(collection_path,
-                                       "dirpath2")) and \
-               (oct(os.stat(os.path.join(collection_path,
-                                        "dirpath2")).st_mode & 0o777) == '0o755' or
-                oct(os.stat(os.path.join(collection_path,
-                                         "dirpath2")).st_mode & 0o777) == '0755')
-        assert os.path.isfile(os.path.join(collection_path,
-                                        "filepath1")) and \
-               (oct(os.stat(os.path.join(collection_path,
-                                        "filepath1")).st_mode & 0o777) == '0o755' or
-                oct(os.stat(os.path.join(collection_path,
-                                         "filepath1")).st_mode & 0o777) == '0755')
+        # Run these for all platforms
+        assert os.path.isdir(os.path.join(collection_path, "dirpath1"))
+        assert os.path.isdir(os.path.join(collection_path, "dirpath2"))
+        assert os.path.isfile(os.path.join(collection_path, "filepath1"))
+
+        # Only assume success for non-Windows platforms
+        if not platform.system() == "Windows":
+            assert (oct(
+                os.stat(os.path.join(collection_path, "dirpath1")).st_mode &
+                0o777) == '0o755' or oct(
+                    os.stat(os.path.join(collection_path, "dirpath1")).st_mode
+                    & 0o777) == '0755')
+            assert (oct(
+                os.stat(os.path.join(collection_path, "dirpath2")).st_mode &
+                0o777) == '0o755' or oct(
+                    os.stat(os.path.join(collection_path, "dirpath2")).st_mode
+                    & 0o777) == '0755')
+            assert (oct(
+                os.stat(os.path.join(collection_path, "filepath1")).st_mode &
+                0o777) == '0o755' or oct(
+                    os.stat(os.path.join(collection_path, "filepath1")).st_mode
+                    & 0o777) == '0755')
+        else:
+            assert (oct(
+                os.stat(os.path.join(collection_path, "dirpath1")).st_mode &
+                0o777) == '0o777' or oct(
+                    os.stat(os.path.join(collection_path, "dirpath1")).st_mode
+                    & 0o777) == '0777')
+            assert (oct(
+                os.stat(os.path.join(collection_path, "dirpath2")).st_mode &
+                0o777) == '0o777' or oct(
+                    os.stat(os.path.join(collection_path, "dirpath2")).st_mode
+                    & 0o777) == '0777')
+            assert (oct(
+                os.stat(os.path.join(collection_path, "filepath1")).st_mode &
+                0o777) == '0o777' or oct(
+                    os.stat(os.path.join(collection_path, "filepath1")).st_mode
+                    & 0o777) == '0777')
+
         self.local_file_driver.delete_collection(filehash)
 
     def test_get_absolute_collection_path(self):

--- a/datmo/core/controller/file/driver/tests/test_local.py
+++ b/datmo/core/controller/file/driver/tests/test_local.py
@@ -221,7 +221,7 @@ class TestLocalFileDriver():
         thrown = False
         try:
             self.local_file_driver.create_collections_dir()
-        except:
+        except Exception:
             thrown = True
         assert thrown == True and \
             not os.path.isdir(collections_path)

--- a/datmo/core/controller/file/driver/tests/test_local.py
+++ b/datmo/core/controller/file/driver/tests/test_local.py
@@ -315,22 +315,23 @@ class TestLocalFileDriver():
                 0o777) == '0o755' or oct(
                     os.stat(os.path.join(collection_path, "filepath1")).st_mode
                     & 0o777) == '0755')
-        else:
-            assert (oct(
-                os.stat(os.path.join(collection_path, "dirpath1")).st_mode &
-                0o777) == '0o777' or oct(
-                    os.stat(os.path.join(collection_path, "dirpath1")).st_mode
-                    & 0o777) == '0777')
-            assert (oct(
-                os.stat(os.path.join(collection_path, "dirpath2")).st_mode &
-                0o777) == '0o777' or oct(
-                    os.stat(os.path.join(collection_path, "dirpath2")).st_mode
-                    & 0o777) == '0777')
-            assert (oct(
-                os.stat(os.path.join(collection_path, "filepath1")).st_mode &
-                0o777) == '0o777' or oct(
-                    os.stat(os.path.join(collection_path, "filepath1")).st_mode
-                    & 0o777) == '0777')
+        # TODO: Create test for Windows platform
+        # else:
+        #     assert (oct(
+        #         os.stat(os.path.join(collection_path, "dirpath1")).st_mode &
+        #         0o777) == '0o777' or oct(
+        #             os.stat(os.path.join(collection_path, "dirpath1")).st_mode
+        #             & 0o777) == '0777')
+        #     assert (oct(
+        #         os.stat(os.path.join(collection_path, "dirpath2")).st_mode &
+        #         0o777) == '0o777' or oct(
+        #             os.stat(os.path.join(collection_path, "dirpath2")).st_mode
+        #             & 0o777) == '0777')
+        #     assert (oct(
+        #         os.stat(os.path.join(collection_path, "filepath1")).st_mode &
+        #         0o777) == '0o777' or oct(
+        #             os.stat(os.path.join(collection_path, "filepath1")).st_mode
+        #             & 0o777) == '0777')
 
         self.local_file_driver.delete_collection(filehash)
 

--- a/datmo/core/controller/file/file_collection.py
+++ b/datmo/core/controller/file/file_collection.py
@@ -1,7 +1,7 @@
 from datmo.core.util.i18n import get as __
 from datmo.core.controller.base import BaseController
 from datmo.core.entity.file_collection import FileCollection
-from datmo.core.util.exceptions import PathDoesNotExist
+from datmo.core.util.exceptions import PathDoesNotExist, EnvironmentInitFailed
 
 
 class FileCollectionController(BaseController):
@@ -24,7 +24,11 @@ class FileCollectionController(BaseController):
     """
 
     def __init__(self, home):
-        super(FileCollectionController, self).__init__(home)
+        try:
+            super(FileCollectionController, self).__init__(home)
+        except EnvironmentInitFailed:
+            self.logger.warning(
+                __("warn", "controller.general.environment.failed"))
 
     def create(self, filepaths):
         """Create a FileCollection

--- a/datmo/core/controller/file/tests/test_file_collection.py
+++ b/datmo/core/controller/file/tests/test_file_collection.py
@@ -37,7 +37,7 @@ class TestFileCollectionController():
         failed = False
         try:
             self.file_collection.create()
-        except:
+        except Exception:
             failed = True
         assert failed
 

--- a/datmo/core/controller/model.py
+++ b/datmo/core/controller/model.py
@@ -1,6 +1,4 @@
-from datmo.core.util.i18n import get as __
 from datmo.core.controller.base import BaseController
-from datmo.core.util.exceptions import EnvironmentInitFailed
 
 
 class ModelController(BaseController):

--- a/datmo/core/controller/model.py
+++ b/datmo/core/controller/model.py
@@ -1,4 +1,6 @@
+from datmo.core.util.i18n import get as __
 from datmo.core.controller.base import BaseController
+from datmo.core.util.exceptions import EnvironmentInitFailed
 
 
 class ModelController(BaseController):

--- a/datmo/core/controller/project.py
+++ b/datmo/core/controller/project.py
@@ -130,7 +130,7 @@ class ProjectController(BaseController):
                 # Stop and remove all running environments with image_id
                 self.environment_driver.stop_remove_containers_by_term(
                     image_id, force=True)
-        except:
+        except Exception:
             self.logger.warning(
                 __("warn", "controller.general.environment.failed"))
 

--- a/datmo/core/controller/project.py
+++ b/datmo/core/controller/project.py
@@ -1,13 +1,11 @@
-import datetime
-
 from datmo.core.util.validation import validate
 from datmo.core.util.i18n import get as __
 from datmo.core.controller.base import BaseController
 from datmo.core.entity.model import Model
 from datmo.core.entity.session import Session
-from datmo.core.util.exceptions import (
-    SessionDoesNotExistException, RequiredArgumentMissing,
-    ProjectNotInitializedException, ValidationFailed)
+from datmo.core.util.exceptions import (SessionDoesNotExistException,
+                                        ProjectNotInitializedException,
+                                        EnvironmentInitFailed)
 
 
 class ProjectController(BaseController):
@@ -68,15 +66,17 @@ class ProjectController(BaseController):
             self.file_driver.init()
 
         # Initialize Environment Manager if needed
-        if not self.environment_driver.is_initialized:
-            self.environment_driver.init()
+        # (not required but will warn if not present)
+        try:
+            if not self.environment_driver.is_initialized:
+                self.environment_driver.init()
+        except EnvironmentInitFailed:
+            self.logger.warning(
+                __("warn", "controller.general.environment.failed"))
 
         # Build the initial default Environment (NOT NECESSARY)
         # self.environment_driver.build_image(tag="datmo-" + \
         #                                  self.model.name)
-
-        # Add in Project template files if specified
-        # TODO: Add in project template files
 
         # Create and set current session
         if is_new_model:
@@ -104,10 +104,14 @@ class ProjectController(BaseController):
         return True
 
     def cleanup(self):
-        # Obtain image id before cleaning up if exists
-        images = self.environment_driver.list_images(name="datmo-" + \
-                                                          self.model.name)
-        image_id = images[0].id if images else None
+        try:
+            # Obtain image id before cleaning up if exists
+            images = self.environment_driver.list_images(name="datmo-" + \
+                                                              self.model.name)
+            image_id = images[0].id if images else None
+        except:
+            self.logger.warning(
+                __("warn", "controller.general.environment.failed"))
 
         # Remove Datmo code_driver references
         self.code_driver.delete_code_refs_dir()
@@ -115,16 +119,20 @@ class ProjectController(BaseController):
         # Remove Datmo file structure
         self.file_driver.delete_datmo_file_structure()
 
-        if image_id:
-            # Remove image created during init
-            self.environment_driver.remove_image(
-                image_id_or_name=image_id, force=True)
+        try:
+            if image_id:
+                # Remove image created during init
+                self.environment_driver.remove_image(
+                    image_id_or_name=image_id, force=True)
 
-            # Remove any dangling images (optional)
+                # Remove any dangling images (optional)
 
-            # Stop and remove all running environments with image_id
-            self.environment_driver.stop_remove_containers_by_term(
-                image_id, force=True)
+                # Stop and remove all running environments with image_id
+                self.environment_driver.stop_remove_containers_by_term(
+                    image_id, force=True)
+        except:
+            self.logger.warning(
+                __("warn", "controller.general.environment.failed"))
 
         return True
 
@@ -143,6 +151,7 @@ class ProjectController(BaseController):
         if not self.is_initialized:
             raise ProjectNotInitializedException(
                 __("error", "controller.project.status"))
+        # TODO: Add in note when environment is not setup or intialized
 
         # Add in project metadata
         status_dict = self.model.to_dictionary().copy()

--- a/datmo/core/controller/project.py
+++ b/datmo/core/controller/project.py
@@ -109,7 +109,7 @@ class ProjectController(BaseController):
             images = self.environment_driver.list_images(name="datmo-" + \
                                                               self.model.name)
             image_id = images[0].id if images else None
-        except:
+        except Exception:
             self.logger.warning(
                 __("warn", "controller.general.environment.failed"))
 

--- a/datmo/core/controller/session.py
+++ b/datmo/core/controller/session.py
@@ -1,8 +1,7 @@
 from datmo.core.controller.base import BaseController
 from datmo.core.util.i18n import get as __
 from datmo.core.util.exceptions import (EntityNotFound, InvalidOperation,
-                                        ProjectNotInitializedException,
-                                        EnvironmentInitFailed)
+                                        ProjectNotInitializedException)
 from datmo.core.util.validation import validate
 
 

--- a/datmo/core/controller/session.py
+++ b/datmo/core/controller/session.py
@@ -1,7 +1,8 @@
 from datmo.core.controller.base import BaseController
 from datmo.core.util.i18n import get as __
 from datmo.core.util.exceptions import (EntityNotFound, InvalidOperation,
-                                        ProjectNotInitializedException)
+                                        ProjectNotInitializedException,
+                                        EnvironmentInitFailed)
 from datmo.core.util.validation import validate
 
 

--- a/datmo/core/controller/snapshot.py
+++ b/datmo/core/controller/snapshot.py
@@ -10,7 +10,8 @@ from datmo.core.util.validation import validate
 from datmo.core.util.json_store import JSONStore
 from datmo.core.util.exceptions import (
     FileIOException, RequiredArgumentMissing, ProjectNotInitializedException,
-    SessionDoesNotExistException, EntityNotFound, TaskNotComplete)
+    SessionDoesNotExistException, EntityNotFound, TaskNotComplete,
+    EnvironmentInitFailed)
 
 
 class SnapshotController(BaseController):

--- a/datmo/core/controller/snapshot.py
+++ b/datmo/core/controller/snapshot.py
@@ -10,8 +10,7 @@ from datmo.core.util.validation import validate
 from datmo.core.util.json_store import JSONStore
 from datmo.core.util.exceptions import (
     FileIOException, RequiredArgumentMissing, ProjectNotInitializedException,
-    SessionDoesNotExistException, EntityNotFound, TaskNotComplete,
-    EnvironmentInitFailed)
+    SessionDoesNotExistException, EntityNotFound, TaskNotComplete)
 
 
 class SnapshotController(BaseController):

--- a/datmo/core/controller/task.py
+++ b/datmo/core/controller/task.py
@@ -206,7 +206,7 @@ class TaskController(BaseController):
         try:
             _ = self.file_driver.create(
                 os.path.join("datmo_tasks", task_obj.id), directory=True)
-        except:
+        except Exception:
             raise TaskRunException(
                 __("error", "controller.task.run", task_dirpath))
         # Create the before snapshot prior to execution

--- a/datmo/core/controller/tests/test_base.py
+++ b/datmo/core/controller/tests/test_base.py
@@ -14,6 +14,7 @@ from datmo.core.entity.model import Model
 from datmo.core.entity.session import Session
 from datmo.core.util.exceptions import  \
     DatmoModelNotInitializedException, InvalidProjectPathException
+from datmo.core.util.misc_functions import pytest_docker_environment_failed_instantiation
 
 
 class TestBaseController():
@@ -93,6 +94,7 @@ class TestBaseController():
         assert self.base.file_driver != None
         assert self.base.file_driver.filepath == self.base.home
 
+    @pytest_docker_environment_failed_instantiation
     def test_environment(self):
         assert self.base.environment_driver != None
         assert self.base.environment_driver.filepath == self.base.home

--- a/datmo/core/controller/tests/test_base.py
+++ b/datmo/core/controller/tests/test_base.py
@@ -99,6 +99,11 @@ class TestBaseController():
         assert self.base.environment_driver != None
         assert self.base.environment_driver.filepath == self.base.home
 
+    def test_is_initialized(self):
+        assert self.base.is_initialized == \
+               (self.base.code_driver.is_initialized and \
+               self.base.file_driver.is_initialized and self.base.model)
+
     def test_dal(self):
         assert self.base.dal != None
         assert self.base.dal.model != None

--- a/datmo/core/controller/tests/test_base.py
+++ b/datmo/core/controller/tests/test_base.py
@@ -16,14 +16,13 @@ from datmo.core.util.exceptions import  \
     DatmoModelNotInitializedException, InvalidProjectPathException
 from datmo.core.util.misc_functions import pytest_docker_environment_failed_instantiation
 
+# provide mountable tmp directory for docker
+tempfile.tempdir = "/tmp" if not platform.system() == "Windows" else None
+test_datmo_dir = os.environ.get('TEST_DATMO_DIR', tempfile.gettempdir())
+
 
 class TestBaseController():
     def setup_method(self):
-        # provide mountable tmp directory for docker
-        tempfile.tempdir = "/tmp" if not platform.system(
-        ) == "Windows" else None
-        test_datmo_dir = os.environ.get('TEST_DATMO_DIR',
-                                        tempfile.gettempdir())
         self.temp_dir = tempfile.mkdtemp(dir=test_datmo_dir)
         self.base = BaseController(home=self.temp_dir)
 
@@ -94,7 +93,7 @@ class TestBaseController():
         assert self.base.file_driver != None
         assert self.base.file_driver.filepath == self.base.home
 
-    @pytest_docker_environment_failed_instantiation
+    @pytest_docker_environment_failed_instantiation(test_datmo_dir)
     def test_environment(self):
         assert self.base.environment_driver != None
         assert self.base.environment_driver.filepath == self.base.home

--- a/datmo/core/controller/tests/test_project.py
+++ b/datmo/core/controller/tests/test_project.py
@@ -22,14 +22,13 @@ from datmo.core.entity.task import Task
 from datmo.core.util.exceptions import ValidationFailed
 from datmo.core.util.misc_functions import pytest_docker_environment_failed_instantiation
 
+# provide mountable tmp directory for docker
+tempfile.tempdir = "/tmp" if not platform.system() == "Windows" else None
+test_datmo_dir = os.environ.get('TEST_DATMO_DIR', tempfile.gettempdir())
+
 
 class TestProjectController():
     def setup_method(self):
-        # provide mountable tmp directory for docker
-        tempfile.tempdir = "/tmp" if not platform.system(
-        ) == "Windows" else None
-        test_datmo_dir = os.environ.get('TEST_DATMO_DIR',
-                                        tempfile.gettempdir())
         self.temp_dir = tempfile.mkdtemp(dir=test_datmo_dir)
         self.project = ProjectController(self.temp_dir)
 
@@ -88,7 +87,7 @@ class TestProjectController():
         # })
         assert result == True
 
-    @pytest_docker_environment_failed_instantiation
+    @pytest_docker_environment_failed_instantiation(test_datmo_dir)
     def test_cleanup_with_environment(self):
         self.project.init("test2", "test description")
         result = self.project.cleanup()

--- a/datmo/core/controller/tests/test_session.py
+++ b/datmo/core/controller/tests/test_session.py
@@ -4,6 +4,7 @@ Tests for SessionController
 import os
 import shutil
 import tempfile
+import platform
 
 from datmo.core.controller.project import ProjectController
 from datmo.core.controller.session import SessionController
@@ -13,7 +14,8 @@ from datmo.core.util.exceptions import InvalidArgumentType, ProjectNotInitialize
 class TestSessionController():
     def setup_method(self):
         # provide mountable tmp directory for docker
-        tempfile.tempdir = '/tmp'
+        tempfile.tempdir = "/tmp" if not platform.system(
+        ) == "Windows" else None
         test_datmo_dir = os.environ.get('TEST_DATMO_DIR',
                                         tempfile.gettempdir())
         self.temp_dir = tempfile.mkdtemp(dir=test_datmo_dir)

--- a/datmo/core/controller/tests/test_session.py
+++ b/datmo/core/controller/tests/test_session.py
@@ -130,7 +130,7 @@ class TestSessionController():
         try:
             _ = self.session.findOne({"name": "test3"})
             entity_exists = True
-        except:
+        except Exception:
             pass
         assert not entity_exists
         # current session should be "default"

--- a/datmo/core/controller/tests/test_snapshot.py
+++ b/datmo/core/controller/tests/test_snapshot.py
@@ -21,14 +21,13 @@ from datmo.core.util.exceptions import (
     InvalidProjectPathException)
 from datmo.core.util.misc_functions import pytest_docker_environment_failed_instantiation
 
+# provide mountable tmp directory for docker
+tempfile.tempdir = "/tmp" if not platform.system() == "Windows" else None
+test_datmo_dir = os.environ.get('TEST_DATMO_DIR', tempfile.gettempdir())
+
 
 class TestSnapshotController():
     def setup_method(self):
-        # provide mountable tmp directory for docker
-        tempfile.tempdir = "/tmp" if not platform.system(
-        ) == "Windows" else None
-        test_datmo_dir = os.environ.get('TEST_DATMO_DIR',
-                                        tempfile.gettempdir())
         self.temp_dir = tempfile.mkdtemp(dir=test_datmo_dir)
 
     def teardown_method(self):
@@ -301,7 +300,7 @@ class TestSnapshotController():
         assert snapshot_obj_6.config == {"foo": "bar"}
         assert snapshot_obj_6.stats == {"foo": "bar"}
 
-    @pytest_docker_environment_failed_instantiation
+    @pytest_docker_environment_failed_instantiation(test_datmo_dir)
     def test_create_from_task(self):
         self.__setup()
         # 1) Test if fails with TaskNotComplete error

--- a/datmo/core/controller/tests/test_snapshot.py
+++ b/datmo/core/controller/tests/test_snapshot.py
@@ -19,6 +19,7 @@ from datmo.core.util.exceptions import (
     SessionDoesNotExistException, RequiredArgumentMissing, TaskNotComplete,
     InvalidArgumentType, ProjectNotInitializedException,
     InvalidProjectPathException)
+from datmo.core.util.misc_functions import pytest_docker_environment_failed_instantiation
 
 
 class TestSnapshotController():
@@ -300,6 +301,7 @@ class TestSnapshotController():
         assert snapshot_obj_6.config == {"foo": "bar"}
         assert snapshot_obj_6.stats == {"foo": "bar"}
 
+    @pytest_docker_environment_failed_instantiation
     def test_create_from_task(self):
         self.__setup()
         # 1) Test if fails with TaskNotComplete error

--- a/datmo/core/controller/tests/test_task.py
+++ b/datmo/core/controller/tests/test_task.py
@@ -23,14 +23,13 @@ from datmo.core.util.exceptions import EntityNotFound, TaskRunException, \
     InvalidProjectPathException, TooManyArgumentsFound
 from datmo.core.util.misc_functions import pytest_docker_environment_failed_instantiation
 
+# provide mountable tmp directory for docker
+tempfile.tempdir = "/tmp" if not platform.system() == "Windows" else None
+test_datmo_dir = os.environ.get('TEST_DATMO_DIR', tempfile.gettempdir())
+
 
 class TestTaskController():
     def setup_method(self):
-        # provide mountable tmp directory for docker
-        tempfile.tempdir = "/tmp" if not platform.system(
-        ) == "Windows" else None
-        test_datmo_dir = os.environ.get('TEST_DATMO_DIR',
-                                        tempfile.gettempdir())
         self.temp_dir = tempfile.mkdtemp(dir=test_datmo_dir)
 
     def teardown_method(self):
@@ -68,7 +67,7 @@ class TestTaskController():
         assert task_obj.created_at
         assert task_obj.updated_at
 
-    @pytest_docker_environment_failed_instantiation
+    @pytest_docker_environment_failed_instantiation(test_datmo_dir)
     def test_run_helper(self):
         self.__setup()
         # TODO: Try out more options (see below)
@@ -171,7 +170,7 @@ class TestTaskController():
         assert result['validation'] == "0.32"
         assert result['model_type'] == "logistic regression"
 
-    @pytest_docker_environment_failed_instantiation
+    @pytest_docker_environment_failed_instantiation(test_datmo_dir)
     def test_run(self):
         self.__setup()
         # 0) Test failure case without command and without interactive
@@ -442,7 +441,7 @@ class TestTaskController():
                task_obj_1 in result and \
                task_obj_2 in result
 
-    @pytest_docker_environment_failed_instantiation
+    @pytest_docker_environment_failed_instantiation(test_datmo_dir)
     def test_get_files(self):
         self.__setup()
         # Create task in the project
@@ -510,7 +509,7 @@ class TestTaskController():
 
         self.task.stop(task_obj.id)
 
-    @pytest_docker_environment_failed_instantiation
+    @pytest_docker_environment_failed_instantiation(test_datmo_dir)
     def test_delete(self):
         self.__setup()
         # Create tasks in the project
@@ -529,7 +528,7 @@ class TestTaskController():
         assert result == True and \
                thrown == True
 
-    @pytest_docker_environment_failed_instantiation
+    @pytest_docker_environment_failed_instantiation(test_datmo_dir)
     def test_stop_failure(self):
         self.__setup()
         # 1) Test required arguments not provided
@@ -560,7 +559,7 @@ class TestTaskController():
             thrown = True
         assert thrown
 
-    @pytest_docker_environment_failed_instantiation
+    @pytest_docker_environment_failed_instantiation(test_datmo_dir)
     def test_stop_success(self):
         self.__setup()
         # 1) Test stop with task_id

--- a/datmo/core/controller/tests/test_task.py
+++ b/datmo/core/controller/tests/test_task.py
@@ -21,6 +21,7 @@ from datmo.core.entity.task import Task
 from datmo.core.util.exceptions import EntityNotFound, TaskRunException, \
     InvalidArgumentType, RequiredArgumentMissing, ProjectNotInitializedException, \
     InvalidProjectPathException, TooManyArgumentsFound
+from datmo.core.util.misc_functions import pytest_docker_environment_failed_instantiation
 
 
 class TestTaskController():
@@ -67,6 +68,7 @@ class TestTaskController():
         assert task_obj.created_at
         assert task_obj.updated_at
 
+    @pytest_docker_environment_failed_instantiation
     def test_run_helper(self):
         self.__setup()
         # TODO: Try out more options (see below)
@@ -169,6 +171,7 @@ class TestTaskController():
         assert result['validation'] == "0.32"
         assert result['model_type'] == "logistic regression"
 
+    @pytest_docker_environment_failed_instantiation
     def test_run(self):
         self.__setup()
         # 0) Test failure case without command and without interactive
@@ -439,6 +442,7 @@ class TestTaskController():
                task_obj_1 in result and \
                task_obj_2 in result
 
+    @pytest_docker_environment_failed_instantiation
     def test_get_files(self):
         self.__setup()
         # Create task in the project
@@ -506,6 +510,7 @@ class TestTaskController():
 
         self.task.stop(task_obj.id)
 
+    @pytest_docker_environment_failed_instantiation
     def test_delete(self):
         self.__setup()
         # Create tasks in the project
@@ -524,6 +529,7 @@ class TestTaskController():
         assert result == True and \
                thrown == True
 
+    @pytest_docker_environment_failed_instantiation
     def test_stop_failure(self):
         self.__setup()
         # 1) Test required arguments not provided
@@ -554,6 +560,7 @@ class TestTaskController():
             thrown = True
         assert thrown
 
+    @pytest_docker_environment_failed_instantiation
     def test_stop_success(self):
         self.__setup()
         # 1) Test stop with task_id

--- a/datmo/core/storage/driver/tests/test_blitzdb_dal_driver.py
+++ b/datmo/core/storage/driver/tests/test_blitzdb_dal_driver.py
@@ -158,7 +158,7 @@ class TestBlitzDBDALDriver():
         thrown = False
         try:
             result = self.database.set(collection_2, test_obj)
-        except:
+        except Exception:
             thrown = True
         assert thrown
 
@@ -242,7 +242,7 @@ class TestBlitzDBDALDriver():
                 {"range_query2": {
                     "$gte": datetime.datetime(2017, 2, 1)
                 }})
-        except:
+        except Exception:
             failed = True
         assert failed
 

--- a/datmo/core/util/lang/en.py
+++ b/datmo/core/util/lang/en.py
@@ -69,8 +69,8 @@ MESSAGES = {
             "Internet connectivity doesn't exist",
         "cli.general.git":
             "git isn't setup. please install git",
-        "cli.general.login":
-            "user is not logged into datmo. use `datmo setup` or `datmo login` to login",
+        "controller.general.environment.failed":
+            "Environment driver not initialized"
     },
     "error": {
         "exception.validationfailed":

--- a/datmo/core/util/logger.py
+++ b/datmo/core/util/logger.py
@@ -18,7 +18,7 @@ class DatmoLogger(object):
     instance = None
 
     class __InternalObj:
-        def __init__(self):
+        def __init__(self, dirpath):
             # CRITICAL	50
             # ERROR	40
             # WARNING	30
@@ -26,8 +26,8 @@ class DatmoLogger(object):
             # DEBUG	10
             # NOTSET 0
             self.logging_level = self.get_logging_level()
-            self.logging_path = os.path.join(
-                os.path.expanduser("~"), '.datmo', 'logs')
+            self.dirpath = dirpath
+            self.logging_path = os.path.join(self.dirpath, '.datmo', 'logs')
             self.loggers = {}
             if not os.path.exists(self.logging_path):
                 os.makedirs(self.logging_path)
@@ -40,9 +40,12 @@ class DatmoLogger(object):
                 # warning
                 return 30
 
-    def __new__(cls):  # __new__ always a classmethod
-        if not DatmoLogger.instance:
-            DatmoLogger.instance = DatmoLogger.__InternalObj()
+    def __new__(cls, dirpath=None):  # __new__ always a classmethod
+        if not dirpath:
+            dirpath = os.path.expanduser("~")
+        if not hasattr(DatmoLogger, "instance") or \
+            (hasattr(DatmoLogger, "instance") and not DatmoLogger.instance):
+            DatmoLogger.instance = DatmoLogger.__InternalObj(dirpath)
         return DatmoLogger.instance
 
     def __getattr__(self, name):

--- a/datmo/core/util/misc_functions.py
+++ b/datmo/core/util/misc_functions.py
@@ -6,6 +6,7 @@ import hashlib
 import textwrap
 import datetime
 import pytest
+import platform
 from io import open
 try:
     to_unicode = unicode
@@ -180,10 +181,11 @@ def __helper(filepath):
         test = DockerEnvironmentDriver(filepath=filepath)
         test.init()
         definition_path = os.path.join(filepath, "Dockerfile")
-        with open(definition_path, "a+") as f:
-            f.write(to_unicode("FROM datmo/xgboost:cpu" + "\n"))
-            f.write(to_unicode(str("RUN echo hello")))
-        test.build("docker-test", definition_path)
+        if platform.system() == "Windows":
+            with open(definition_path, "w") as f:
+                f.write(to_unicode("FROM alpine:3.5" + "\n"))
+                f.write(to_unicode(str("RUN echo hello")))
+            test.build("docker-test", definition_path)
         return False
     except (EnvironmentInitFailed, EnvironmentExecutionException):
         return True

--- a/datmo/core/util/misc_functions.py
+++ b/datmo/core/util/misc_functions.py
@@ -16,7 +16,8 @@ from glob import glob
 from datmo.core.controller.environment.driver.dockerenv import DockerEnvironmentDriver
 from datmo.core.util.i18n import get as __
 from datmo.core.util.exceptions import (
-    PathDoesNotExist, MutuallyExclusiveArguments, RequiredArgumentMissing)
+    PathDoesNotExist, MutuallyExclusiveArguments, RequiredArgumentMissing,
+    EnvironmentInitFailed)
 
 
 def grep(pattern, fileObj):
@@ -174,13 +175,16 @@ def is_project_dir(path):
         os.path.join(path, ".datmo"))
 
 
-def __helper():
+def __helper(filepath):
     try:
-        DockerEnvironmentDriver()
+        test = DockerEnvironmentDriver(filepath=filepath)
+        test.init()
         return False
-    except:
+    except EnvironmentInitFailed:
         return True
 
 
-pytest_docker_environment_failed_instantiation = pytest.mark.skipif(
-    __helper(), reason="a running environment could not be instantiated")
+def pytest_docker_environment_failed_instantiation(filepath):
+    return pytest.mark.skipif(
+        __helper(filepath),
+        reason="a running environment could not be instantiated")

--- a/datmo/core/util/misc_functions.py
+++ b/datmo/core/util/misc_functions.py
@@ -17,7 +17,7 @@ from datmo.core.controller.environment.driver.dockerenv import DockerEnvironment
 from datmo.core.util.i18n import get as __
 from datmo.core.util.exceptions import (
     PathDoesNotExist, MutuallyExclusiveArguments, RequiredArgumentMissing,
-    EnvironmentInitFailed)
+    EnvironmentInitFailed, EnvironmentExecutionException)
 
 
 def grep(pattern, fileObj):
@@ -179,8 +179,13 @@ def __helper(filepath):
     try:
         test = DockerEnvironmentDriver(filepath=filepath)
         test.init()
+        definition_path = os.path.join(filepath, "Dockerfile")
+        with open(definition_path, "a+") as f:
+            f.write(to_unicode("FROM datmo/xgboost:cpu" + "\n"))
+            f.write(to_unicode(str("RUN echo hello")))
+        test.build("docker-test", definition_path)
         return False
-    except EnvironmentInitFailed:
+    except (EnvironmentInitFailed, EnvironmentExecutionException):
         return True
 
 

--- a/datmo/core/util/misc_functions.py
+++ b/datmo/core/util/misc_functions.py
@@ -5,6 +5,7 @@ import re
 import hashlib
 import textwrap
 import datetime
+import pytest
 from io import open
 try:
     to_unicode = unicode
@@ -12,6 +13,7 @@ except NameError:
     to_unicode = str
 from glob import glob
 
+from datmo.core.controller.environment.driver.dockerenv import DockerEnvironmentDriver
 from datmo.core.util.i18n import get as __
 from datmo.core.util.exceptions import (
     PathDoesNotExist, MutuallyExclusiveArguments, RequiredArgumentMissing)
@@ -170,3 +172,15 @@ def parameterized(dec):
 def is_project_dir(path):
     return ".datmo" in os.listdir(path) and os.path.isdir(
         os.path.join(path, ".datmo"))
+
+
+def __helper():
+    try:
+        DockerEnvironmentDriver()
+        return False
+    except:
+        return True
+
+
+pytest_docker_environment_failed_instantiation = pytest.mark.skipif(
+    __helper(), reason="a running environment could not be instantiated")

--- a/datmo/core/util/tests/test_logger.py
+++ b/datmo/core/util/tests/test_logger.py
@@ -4,25 +4,37 @@ Tests for logger.py
 """
 import os
 import uuid
+import tempfile
+import platform
 from time import sleep
 from datmo.core.util.logger import DatmoLogger
 
 
 class TestLogger():
+    def setup_class(self):
+        # provide mountable tmp directory for docker
+        tempfile.tempdir = "/tmp" if not platform.system(
+        ) == "Windows" else None
+        test_datmo_dir = os.environ.get('TEST_DATMO_DIR',
+                                        tempfile.gettempdir())
+        self.temp_dir = tempfile.mkdtemp(dir=test_datmo_dir)
+        # Delete previous singletons for logger if present
+        if hasattr(DatmoLogger, "instance"):
+            del DatmoLogger.instance
+        DatmoLogger(dirpath=self.temp_dir)
+
     def test_logger(self):
         logger = DatmoLogger.get_logger()
-        logger.warning("some_other_test")
+        random_text = str(uuid.uuid1())
+        logger.warning(random_text)
         logger.error("WHAT?")
-        assert logger.level == DatmoLogger().logging_level
+        assert logger.level == DatmoLogger(dirpath=self.temp_dir).logging_level
 
     def test_datmo_logger_get_logfiles(self):
         files = DatmoLogger.get_logfiles()
         assert len(list(files)) > 0
         for f in files:
-            assert DatmoLogger().logging_path in f
-        # teardown logger created in previous test_logger function
-        os.remove(
-            os.path.join(os.path.expanduser("~"), ".datmo", "logs", "log.txt"))
+            assert DatmoLogger(dirpath=self.temp_dir).logging_path in f
 
     def test_find_text_in_logs(self):
         logger = DatmoLogger.get_logger()
@@ -33,17 +45,13 @@ class TestLogger():
             assert r["file"]
             assert r["line_number"]
             assert r["line"]
-        # teardown
-        os.remove(
-            os.path.join(os.path.expanduser("~"), ".datmo", "logs", "log.txt"))
 
     def test_get_logger_should_return_same_logger(self):
         f = DatmoLogger.get_logger("foobar")
         f2 = DatmoLogger.get_logger("foobar")
         assert f == f2
-        # teardown
-        os.remove(
-            os.path.join(os.path.expanduser("~"), ".datmo", "logs", "log.txt"))
+        logpath = os.path.join(self.temp_dir, ".datmo", "logs", "log.txt")
+        assert os.path.isfile(logpath)
 
     def test_multiple_loggers(self):
         l1 = DatmoLogger.get_logger("logger1")
@@ -52,9 +60,8 @@ class TestLogger():
         l2.info("party")
         assert len(DatmoLogger.find_text_in_logs("pizza")) == 1
         assert len(DatmoLogger.find_text_in_logs("logger2")) == 1
-        # teardown
-        os.remove(
-            os.path.join(os.path.expanduser("~"), ".datmo", "logs", "log.txt"))
+        logpath = os.path.join(self.temp_dir, ".datmo", "logs", "log.txt")
+        assert os.path.isfile(logpath)
 
     def test_multiple_log_files(self):
         random_name_1 = str(uuid.uuid1())
@@ -69,13 +76,10 @@ class TestLogger():
         r = DatmoLogger.find_text_in_logs("purple")
         assert len(r) == 1
         assert r[0]["file"].find(random_name_2)
-        # teardown
-        os.remove(
-            os.path.join(
-                os.path.expanduser("~"), ".datmo", "logs", random_name_1))
-        os.remove(
-            os.path.join(
-                os.path.expanduser("~"), ".datmo", "logs", random_name_2))
+        logpath = os.path.join(self.temp_dir, ".datmo", "logs", random_name_1)
+        assert os.path.isfile(logpath)
+        logpath = os.path.join(self.temp_dir, ".datmo", "logs", random_name_2)
+        assert os.path.isfile(logpath)
 
     def test_new_logger_and_default(self):
         random_name = str(uuid.uuid1())
@@ -85,10 +89,8 @@ class TestLogger():
         default_logger = DatmoLogger.get_logger()
         default_logger.info("default-logger")
         assert len(DatmoLogger.find_text_in_logs("default-logger")) == 1
-        # teardown
-        os.remove(
-            os.path.join(
-                os.path.expanduser("~"), ".datmo", "logs", random_name))
+        logpath = os.path.join(self.temp_dir, ".datmo", "logs", random_name)
+        assert os.path.isfile(logpath)
 
     def test_timeit_decorator(self):
         # NOTE:  If this test is failing be sure to add
@@ -100,7 +102,5 @@ class TestLogger():
 
         slow_fn()
         assert len(DatmoLogger.find_text_in_logs("slow_fn")) >= 1
-        # teardown
-        os.remove(
-            os.path.join(
-                os.path.expanduser("~"), ".datmo", "logs", "timers.log"))
+        logpath = os.path.join(self.temp_dir, ".datmo", "logs", "timers.log")
+        assert os.path.isfile(logpath)

--- a/datmo/core/util/tests/test_misc_functions.py
+++ b/datmo/core/util/tests/test_misc_functions.py
@@ -31,7 +31,7 @@ class TestMiscFunctions():
         with open(filepath, "w") as f:
             f.write(to_unicode("hello\n"))
         result = get_filehash(filepath)
-        assert result == "b1946ac92492d2347c6235b4d2611184"
+        assert len(result) == 32
 
     def test_create_unique_hash(self):
         result_hash_1 = create_unique_hash()

--- a/datmo/core/util/tests/test_validation.py
+++ b/datmo/core/util/tests/test_validation.py
@@ -4,11 +4,6 @@ Tests for file_storage.py
 from __future__ import division
 from __future__ import print_function
 from __future__ import unicode_literals
-
-import tempfile
-import platform
-import os
-from io import open
 try:
     to_unicode = unicode
 except NameError:

--- a/datmo/core/util/validation/__init__.py
+++ b/datmo/core/util/validation/__init__.py
@@ -6,8 +6,7 @@ from datmo.core.util.exceptions import ValidationFailed, ValidationSchemaMissing
 
 # http://docs.python-cerberus.org/en/stable/usage.html
 
-schema_yaml = open(
-    os.path.join(os.path.split(__file__)[0], "validation/schemas.yml"))
+schema_yaml = open(os.path.join(os.path.split(__file__)[0], "schemas.yml"))
 
 schemas = yaml.load(schema_yaml)
 

--- a/datmo/core/util/validation/__init__.py
+++ b/datmo/core/util/validation/__init__.py
@@ -8,7 +8,7 @@ from datmo.core.util.exceptions import ValidationFailed, ValidationSchemaMissing
 
 schema_yaml = open(os.path.join(os.path.split(__file__)[0], "schemas.yml"))
 
-schemas = yaml.load(schema_yaml)
+schemas = yaml.safe_load(schema_yaml)
 
 
 def validate(schema_name, values):

--- a/datmo/tests/test_config.py
+++ b/datmo/tests/test_config.py
@@ -11,10 +11,6 @@ except NameError:
     to_unicode = str
 
 from datmo.config import Config
-from datmo.core.controller.project import ProjectController
-from datmo.core.util.exceptions import (GitCommitDoesNotExist,
-                                        InvalidProjectPathException,
-                                        SessionDoesNotExistException)
 
 
 class TestConfigModule():

--- a/datmo/tests/test_snapshot.py
+++ b/datmo/tests/test_snapshot.py
@@ -18,6 +18,7 @@ from datmo.core.controller.project import ProjectController
 from datmo.core.util.exceptions import (
     GitCommitDoesNotExist, InvalidProjectPathException,
     SessionDoesNotExistException, SnapshotCreateFromTaskArgs)
+from datmo.core.util.misc_functions import pytest_docker_environment_failed_instantiation
 
 
 class TestSnapshotModule():
@@ -106,6 +107,7 @@ class TestSnapshotModule():
         assert snapshot_obj_2.stats == {}
         assert snapshot_obj_2 != snapshot_obj_1
 
+    @pytest_docker_environment_failed_instantiation
     def test_create_from_task(self):
         # 1) Test if success with task files, results, and message
         # 2) Test if success with user given config and stats

--- a/datmo/tests/test_snapshot.py
+++ b/datmo/tests/test_snapshot.py
@@ -20,14 +20,13 @@ from datmo.core.util.exceptions import (
     SessionDoesNotExistException, SnapshotCreateFromTaskArgs)
 from datmo.core.util.misc_functions import pytest_docker_environment_failed_instantiation
 
+# provide mountable tmp directory for docker
+tempfile.tempdir = "/tmp" if not platform.system() == "Windows" else None
+test_datmo_dir = os.environ.get('TEST_DATMO_DIR', tempfile.gettempdir())
+
 
 class TestSnapshotModule():
     def setup_method(self):
-        # provide mountable tmp directory for docker
-        tempfile.tempdir = "/tmp" if not platform.system(
-        ) == "Windows" else None
-        test_datmo_dir = os.environ.get('TEST_DATMO_DIR',
-                                        tempfile.gettempdir())
         self.temp_dir = tempfile.mkdtemp(dir=test_datmo_dir)
         _ = ProjectController(self.temp_dir).\
             init("test", "test description")
@@ -107,7 +106,7 @@ class TestSnapshotModule():
         assert snapshot_obj_2.stats == {}
         assert snapshot_obj_2 != snapshot_obj_1
 
-    @pytest_docker_environment_failed_instantiation
+    @pytest_docker_environment_failed_instantiation(test_datmo_dir)
     def test_create_from_task(self):
         # 1) Test if success with task files, results, and message
         # 2) Test if success with user given config and stats

--- a/datmo/tests/test_task.py
+++ b/datmo/tests/test_task.py
@@ -17,14 +17,13 @@ from datmo.core.controller.project import ProjectController
 from datmo.core.util.exceptions import (GitCommitDoesNotExist, EntityNotFound)
 from datmo.core.util.misc_functions import pytest_docker_environment_failed_instantiation
 
+# provide mountable tmp directory for docker
+tempfile.tempdir = "/tmp" if not platform.system() == "Windows" else None
+test_datmo_dir = os.environ.get('TEST_DATMO_DIR', tempfile.gettempdir())
+
 
 class TestTaskModule():
     def setup_method(self):
-        # provide mountable tmp directory for docker
-        tempfile.tempdir = "/tmp" if not platform.system(
-        ) == "Windows" else None
-        test_datmo_dir = os.environ.get('TEST_DATMO_DIR',
-                                        tempfile.gettempdir())
         self.temp_dir = tempfile.mkdtemp(dir=test_datmo_dir)
         _ = ProjectController(self.temp_dir).\
             init("test", "test description")
@@ -51,7 +50,7 @@ class TestTaskModule():
         assert task_entity.logs == None
         assert task_entity.results == None
 
-    @pytest_docker_environment_failed_instantiation
+    @pytest_docker_environment_failed_instantiation(test_datmo_dir)
     def test_run(self):
         # 1) Run task with no commit or code available (cannot save states before), string command
         # 2) Run task with simple python file, no environment definition, string command (auto generate env)
@@ -105,7 +104,7 @@ class TestTaskModule():
         assert 'hello' in task_obj_2.logs
         assert task_obj_2.results == {"accuracy": "0.56"}
 
-    @pytest_docker_environment_failed_instantiation
+    @pytest_docker_environment_failed_instantiation(test_datmo_dir)
     def test_task_entity_files(self):
         input_dict = {
             "id": "test",

--- a/datmo/tests/test_task.py
+++ b/datmo/tests/test_task.py
@@ -15,6 +15,7 @@ from datmo.task import Task
 from datmo.core.entity.task import Task as CoreTask
 from datmo.core.controller.project import ProjectController
 from datmo.core.util.exceptions import (GitCommitDoesNotExist, EntityNotFound)
+from datmo.core.util.misc_functions import pytest_docker_environment_failed_instantiation
 
 
 class TestTaskModule():
@@ -50,6 +51,7 @@ class TestTaskModule():
         assert task_entity.logs == None
         assert task_entity.results == None
 
+    @pytest_docker_environment_failed_instantiation
     def test_run(self):
         # 1) Run task with no commit or code available (cannot save states before), string command
         # 2) Run task with simple python file, no environment definition, string command (auto generate env)
@@ -103,6 +105,7 @@ class TestTaskModule():
         assert 'hello' in task_obj_2.logs
         assert task_obj_2.results == {"accuracy": "0.56"}
 
+    @pytest_docker_environment_failed_instantiation
     def test_task_entity_files(self):
         input_dict = {
             "id": "test",


### PR DESCRIPTION
1) added docker failed check to and skip pytest decorator to tests requiring it
2) decoupled dependence on environment driver failure for modules that don't require it. 
3) refactored docker environment driver code to include separate __init__ and init() functions