### PR TITLE
updating entities for run while using data option

### DIFF
--- a/datmo/cli/command/base.py
+++ b/datmo/cli/command/base.py
@@ -131,12 +131,23 @@ class BaseCommand(object):
                     _, _, task_dict['data_file_path_map'], task_dict['data_directory_path_map'] = \
                         parse_paths(self.task_controller.home, data_paths, '/data')
                 except PathDoesNotExist as e:
+                    status = "NOT STARTED"
+                    workspace = task_dict.get('workspace', None)
+                    command = task_dict.get('command', None)
+                    command_list = task_dict.get('command_list', None)
+                    interactive = task_dict.get('interactive', False)
+                    self.task_controller.update(task_obj.id,
+                                                workspace=workspace,
+                                                command=command,
+                                                command_list=command_list,
+                                                interactive=interactive)
                     self.cli_helper.echo(__("error", "cli.run.parse.paths", str(e)))
                     return False
 
             updated_task_obj = self.task_controller.run(
                 task_obj.id, snapshot_dict=snapshot_dict, task_dict=task_dict)
             status = "SUCCESS"
+            self.cli_helper.echo(__("info", "cli.run.run.stop"))
         except Exception as e:
             status = "FAILED"
             self.logger.error("%s %s" % (e, task_dict))
@@ -144,11 +155,10 @@ class BaseCommand(object):
             self.cli_helper.echo(__("error", error_identifier, task_obj.id))
             return False
         finally:
-            self.cli_helper.echo(__("info", "cli.run.run.stop"))
             self.task_controller.stop(
                 task_id=updated_task_obj.id, status=status)
-            self.cli_helper.echo(
-                __("info", "cli.run.run.complete", updated_task_obj.id))
+        self.cli_helper.echo(
+            __("info", "cli.run.run.complete", updated_task_obj.id))
 
         return updated_task_obj
 

--- a/datmo/cli/command/tests/test_run.py
+++ b/datmo/cli/command/tests/test_run.py
@@ -44,7 +44,7 @@ from datmo.cli.command.run import RunObject
 from datmo.cli.command.run import RunCommand
 from datmo.core.entity.task import Task as CoreTask
 from datmo.core.util.exceptions import SessionDoesNotExist, DoesNotExist, \
-    MutuallyExclusiveArguments, RequiredArgumentMissing
+    MutuallyExclusiveArguments, RequiredArgumentMissing, PathDoesNotExist
 from datmo.core.util.misc_functions import pytest_docker_environment_failed_instantiation
 
 # provide mountable tmp directory for docker
@@ -240,6 +240,15 @@ class TestRunCommand():
         self.run_command.parse(["stop", "--all"])
         # test when all is passed to stop all
         self.run_command.execute()
+
+        # test failure
+        test_data_dir_dne = os.path.join(tempfile.mkdtemp(dir=test_datmo_dir), "data_dne")
+        self.run_command.parse([
+                "run", "--environment-paths", test_dockerfile,
+                "--data", test_data_dir_dne
+            ])
+        result = self.run_command.execute()
+        assert not result
 
     @pytest_docker_environment_failed_instantiation(test_datmo_dir)
     def test_run_string_command(self):

--- a/datmo/core/controller/task.py
+++ b/datmo/core/controller/task.py
@@ -544,6 +544,41 @@ class TaskController(BaseController):
             # Error because the task does not have any files associated with it
             raise PathDoesNotExist()
 
+    def update(self,
+               task_id,
+               workspace=None,
+               command=None,
+               command_list=None,
+               interactive=False):
+        """Update the task metadata"""
+        if not task_id:
+            raise RequiredArgumentMissing(
+                __("error", "controller.task.delete.arg", "id"))
+        if command_list:
+            command = " ".join(command_list)
+        elif command:
+            command_list = shlex.split(command)
+
+        validate(
+            "update_task", {
+                "workspace": workspace,
+                "command": command,
+                "command_list": command_list,
+                "interactive": interactive
+            })
+        update_task_input_dict = {'id': task_id}
+
+        if workspace is not None:
+            update_task_input_dict['workspace'] = workspace
+        if command is not None:
+            update_task_input_dict['command'] = command
+        if command_list is not None:
+            update_task_input_dict['command_list'] = command_list
+        if interactive:
+            update_task_input_dict['interactive'] = interactive
+
+        return self.dal.task.update(update_task_input_dict)
+
     def delete(self, task_id):
         if not task_id:
             raise RequiredArgumentMissing(

--- a/datmo/core/controller/tests/test_task.py
+++ b/datmo/core/controller/tests/test_task.py
@@ -798,6 +798,19 @@ class TestTaskController():
         assert updated_task_obj.command == test_command
         assert updated_task_obj.command_list == ["python", "script.py"]
 
+        # Test 3: When meta data for workspace is passed
+        test_interactive = True
+        updated_task_obj = self.task_controller.update(task_obj.id,
+                                                       interactive=test_interactive)
+        assert updated_task_obj.interactive == test_interactive
+
+        # Test 4: When meta data for workspace is passed
+        test_command_list = ["python", "script.py"]
+        updated_task_obj = self.task_controller.update(task_obj.id,
+                                                       command_list=test_command_list)
+        assert updated_task_obj.command_list == ["python", "script.py"]
+
+
     @pytest_docker_environment_failed_instantiation(test_datmo_dir)
     def test_delete(self):
         self.__setup()

--- a/datmo/core/controller/tests/test_task.py
+++ b/datmo/core/controller/tests/test_task.py
@@ -778,6 +778,26 @@ class TestTaskController():
 
         self.task_controller.stop(task_obj.id)
 
+    def test_update(self):
+        self.__setup()
+        # Create task in the project
+        task_obj = self.task_controller.create()
+        assert isinstance(task_obj, Task)
+
+        # Test 1: When no meta data is passed
+        updated_task_obj = self.task_controller.update(task_obj.id)
+        assert updated_task_obj.workspace is None
+
+        # Test 2: When meta data for workspace is passed
+        test_workspace = "notebook"
+        test_command = "python script.py"
+        updated_task_obj = self.task_controller.update(task_obj.id,
+                                                       workspace=test_workspace,
+                                                       command=test_command)
+        assert updated_task_obj.workspace == test_workspace
+        assert updated_task_obj.command == test_command
+        assert updated_task_obj.command_list == ["python", "script.py"]
+
     @pytest_docker_environment_failed_instantiation(test_datmo_dir)
     def test_delete(self):
         self.__setup()

--- a/datmo/core/util/validation/schemas.yml
+++ b/datmo/core/util/validation/schemas.yml
@@ -137,3 +137,16 @@ create_task:
   data_directory_path_map:
     nullable: true
     type: list
+
+update_task:
+  workspace:
+    nullable: true
+    type: string
+  command:
+    nullable: true
+    type: string
+  command_list:
+    nullable: true
+    type: list
+  interactive:
+    type: boolean


### PR DESCRIPTION
1. Updating status to "NOT STARTED" when the data path does not exist.
2. Updating the workspace, command, command_list and interactive attributes when the run hasn't started https://github.com/datmo/datmo/issues/247