### PR TITLE
configure only key

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -25,3 +25,4 @@ env:
   global:
     - LOGGING_LEVEL=DEBUG
     - SLACK_WEBHOOK_URL=https://hooks.slack.com/services/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
+    - DATMO_API_KEY=6a3a3cd900eaf7b406a41d68f8ca7969

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -8,6 +8,7 @@ environment:
     CMD_IN_ENV: "cmd /E:ON /V:ON /C .\\appveyor\\run_with_env.cmd"
   LOGGING_LEVEL: DEBUG
   SLACK_WEBHOOK_URL: https://hooks.slack.com/services/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
+  DATMO_API_KEY: 6a3a3cd900eaf7b406a41d68f8ca7969
 
   matrix:
     - PYTHON: "C:\\Python27"

--- a/circle.yml
+++ b/circle.yml
@@ -6,6 +6,7 @@ machine:
   environment:
     LOGGING_LEVEL: DEBUG
     SLACK_WEBHOOK_URL: "https://hooks.slack.com/services/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"
+    DATMO_API_KEY: "6a3a3cd900eaf7b406a41d68f8ca7969"
     TEST_PACKAGE: python -m pytest -s -v
 
   pre:

--- a/datmo/cli/command/project.py
+++ b/datmo/cli/command/project.py
@@ -3,6 +3,7 @@ import os
 from datmo import __version__
 from datmo.core.util.i18n import get as __
 from datmo.core.util.json_store import JSONStore
+from datmo.core.util.remote_api import RemoteAPI
 from datmo.cli.driver.helper import Helper
 from datmo.cli.command.base import BaseCommand
 from datmo.core.controller.project import ProjectController
@@ -162,11 +163,17 @@ class ProjectCommand(BaseCommand):
 
         if setup_remote_bool:
             datmo_api_key = None
-            master_server_ip = None
 
             while not datmo_api_key:
                 datmo_api_key = self.cli_helper.prompt(
                     "---> Enter API key for Datmo Deployment")
+
+            # Initialize remote API to get master ip address
+            remote_api = RemoteAPI(datmo_api_key)
+            response = remote_api.get_deployment_info()
+            master_system_info = response['body']['master_system_info']
+            master_server_ip = str(master_system_info.get('datmo_master_ip')) if isinstance(master_system_info, dict)\
+                else None
 
             while not master_server_ip:
                 master_server_ip = self.cli_helper.prompt(

--- a/datmo/config.py
+++ b/datmo/config.py
@@ -41,14 +41,15 @@ class Config(object):
         @property
         def remote_credentials(self):
             # Load from .datmo/config global file
-            MASTER_SERVER_IP, DATMO_API_KEY, END_POINT = None, None, None
+            MASTER_SERVER_IP, DATMO_API_KEY, END_POINT = os.environ.get('MASTER_SERVER_IP'),\
+                                                         os.environ.get('DATMO_API_KEY'), None
             # loading the datmo config
             datmo_config = JSONStore(
                 os.path.join(os.path.expanduser("~"), ".datmo", "config"))
             config_dict = datmo_config.to_dict()
 
-            MASTER_SERVER_IP = config_dict.get('MASTER_SERVER_IP', None)
-            DATMO_API_KEY = config_dict.get('DATMO_API_KEY', None)
+            if MASTER_SERVER_IP is None: MASTER_SERVER_IP = config_dict.get('MASTER_SERVER_IP', None)
+            if DATMO_API_KEY is None: DATMO_API_KEY = config_dict.get('DATMO_API_KEY', None)
 
             if MASTER_SERVER_IP:
                 END_POINT = 'http://' + MASTER_SERVER_IP + ':2083/api/v1'

--- a/datmo/monitoring.py
+++ b/datmo/monitoring.py
@@ -5,6 +5,7 @@ import json
 import psutil
 from datetime import datetime
 
+from datmo.config import Config
 from datmo.core.util.exceptions import InputError
 from datmo.core.util.misc_functions import bytes2human, slack_message
 from datmo.core.util.remote_api import RemoteAPI
@@ -63,8 +64,12 @@ class Monitoring():
     >>> datmo_client.trigger(medium="slack", input=input, prediction=prediction, notes=notes)
     """
 
-    def __init__(self, api_key, home=None):
-        self._api_key = api_key
+    def __init__(self, api_key=None):
+        if api_key is None:
+            config = Config()
+            _, self._api_key, _ = config.remote_credentials
+        else:
+            self._api_key = api_key
         self.remote_api = RemoteAPI(self._api_key)
         self._start_time, self._end_time, self._model_id, \
         self._model_version_id, self._deployment_version_id = None, None, None, None, None

--- a/datmo/tests/test_monitoring.py
+++ b/datmo/tests/test_monitoring.py
@@ -24,8 +24,7 @@ class TestMonitoringModule():
                                         tempfile.gettempdir())
         self.temp_dir = tempfile.mkdtemp(dir=test_datmo_dir)
         # TODO: move API key to environment variable
-        self.monitoring = Monitoring(
-            api_key="6a3a3cd900eaf7b406a41d68f8ca7969")
+        self.monitoring = Monitoring()
         self.monitoring.__str__()
         self.monitoring.__repr__()
         self.monitoring.set_model_id("model_id")


### PR DESCRIPTION
- [ ] Save datmo master IP address after passing only the API key
- [ ] Read API key from cache or environment variable for Monitoring SDK